### PR TITLE
Catharsis 1.0.0-beta.10

### DIFF
--- a/docs/entity_overrides/index.md
+++ b/docs/entity_overrides/index.md
@@ -1,0 +1,76 @@
+---
+title: Entity Overrides
+lang: en-US
+---
+
+# How to override Entity Overrides
+
+Provide a json at `{your_name_space}:catharsis/entity_definitions/{entity_name}.json`
+
+with the following format:
+
+```json
+{
+    "target": {
+        "type": "...",
+        ...
+    },
+    "type": "minecraft:..."
+}
+```
+
+and another json at `{your_name_here}:catharsis/entities/{entity_name}.json`
+
+with the following format:
+
+```json
+{
+    "texture": "{your_name_space}:textures/{texture path here}.png",
+    "model": "{your_name_space}:models/{model_path_here}.geo.json"
+}
+```
+
+and put a texture where the texture path leads to and a bedrock entity geometry (`.geo.json`) where that one points to. 
+If you use vanillas names for the bones, the model will use their animation. If something has the wrong name, the mod send a log about that.
+
+
+## Condition Types
+
+Multiple different definitions.
+
+### `"type": "all" OR "any"`
+Use multiple conditions in combination with each other
+`"all"` matches every condition in the list, `"any"` matches if any condition is matched 
+keys:
+`"conditions"`: a list of conditions
+
+### `"type": "npc_skin" OR "player_skin"`
+lets you access state about a player entity
+keys:
+`"skin"`: a reference to a skin url, if the entity matches this skin _exactly_ it is used
+
+### `"type": "identity"`
+lets you access state about regular entities
+keys:
+`"uuid"`: matches the entity's uuid. skyblock mostly uses random uuids
+`"name"`: matches the entity's name
+
+### `"type": "attribute"`
+allows access to entity attributes (such as max health)
+keys:
+`"attribute"`: which attribute to check
+`"value"` or `"values"`: matches one or multiple values
+
+### `"type": "island"`
+matches if you are on an island
+keys:
+`"island"` or `"islands"`: matches one or multiple islands
+
+### `"type": "equipment"`
+matches the entity's equipment
+keys:
+`"slot"`: which slot to check
+`"property"`: what BOOLEAN property to check (this can add more keys)
+
+## Model quirks
+Cannot handle per-face uv. will break. Everything else _should_ work fine

--- a/docs/example_pack/assets/your_name_space/catharsis/entity_definitions/graveyard_zombie.json
+++ b/docs/example_pack/assets/your_name_space/catharsis/entity_definitions/graveyard_zombie.json
@@ -1,0 +1,13 @@
+{
+  "target": {
+    "type": "all",
+    "conditions": [
+      {
+        "type": "attribute",
+        "attribute": "minecraft:max_health",
+        "value": 100
+      }
+    ]
+  },
+  "type": "minecraft:zombie"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4G
 ksp.incremental=false
 
-version=1.0.0-beta.9
+version=1.0.0-beta.10

--- a/repo/guis/collections/collections.json
+++ b/repo/guis/collections/collections.json
@@ -1,0 +1,80 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Collections"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:collections/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/farming/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Farming Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/mining/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Mining Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/combat/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Combat Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/foraging/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Foraging Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/fishing/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Fishing Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/boss/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/rift/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Rift Collections"
+      }
+    },
+    {
+      "id": "skyblock_gui:collections/crafted_minions/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Crafted Minions"
+      }
+    }
+  ]
+}

--- a/repo/guis/generic/generic.json
+++ b/repo/guis/generic/generic.json
@@ -6,7 +6,7 @@
   },
   "layout": [
     {
-      "id": "skyblock_gui:generic/filler",
+      "id": "skyblock_gui:generic/miscellaneous/filler",
       "target": {
         "type": "all",
         "conditions": [
@@ -15,62 +15,21 @@
           },
           {
             "type": "item",
-            "items": [
-              "minecraft:black_stained_glass_pane"
-            ]
+            "items": ["minecraft:black_stained_glass_pane"]
           }
         ]
       }
     },
     {
-      "id": "skyblock_gui:generic/close",
+      "id": "skyblock_gui:generic/miscellaneous/filler",
       "target": {
         "type": "name",
         "mode": "equals",
-        "name": "Close"
+        "name": "Information"
       }
     },
     {
-      "id": "skyblock_gui:generic/go_back",
-      "target": {
-        "type": "name",
-        "mode": "equals",
-        "name": "Go Back"
-      }
-    },
-    {
-      "id": "skyblock_gui:generic/previous_page",
-      "target": {
-        "type": "name",
-        "mode": "equals",
-        "name": "Previous Page"
-      }
-    },
-    {
-      "id": "skyblock_gui:generic/next_page",
-      "target": {
-        "type": "name",
-        "name": "Next Page|(?:Levels|Mastery) \\d+ - \\d+"
-      }
-    },
-    {
-      "id": "skyblock_gui:generic/scroll_up",
-      "target": {
-        "type": "name",
-        "mode": "equals",
-        "name": "Scroll Up"
-      }
-    },
-    {
-      "id": "skyblock_gui:generic/scroll_down",
-      "target": {
-        "type": "name",
-        "mode": "equals",
-        "name": "Scroll Down"
-      }
-    },
-    {
-      "id": "skyblock_gui:generic/settings",
+      "id": "skyblock_gui:generic/settings/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -78,11 +37,176 @@
       }
     },
     {
-      "id": "skyblock_gui:generic/sell_item",
+      "id": "skyblock_gui:generic/settings/enabled",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "item",
+            "items": "lime_dye"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to disable!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/settings/disabled",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "item",
+            "items": "gray_dye"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to enable!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/settings/disabled",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Settings"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/close",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Close"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/go_back",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Go Back"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/previous_page",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Previous Page"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/next_page",
+      "target": {
+        "type": "name",
+        "name": "Next Page|(?:Levels|Mastery) \\d+ - \\d+"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/scroll_up",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Scroll Up"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/scroll_down",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Scroll Down"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/search",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Search"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/inventory_management/sell_item",
       "target": {
         "type": "name",
         "mode": "equals",
         "name": "Sell Item"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/inventory_management/sell_inventory_now",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Sell Inventory Now"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/inventory_management/sell_sacks_now",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Sell Sacks Now"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/inventory_management/insert_inventory",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Insert inventory"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/inventory_management/pickup_all",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Pickup All"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/currency/bits",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "item",
+            "items": "diamond"
+          },
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Bits"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/currency/skyblock_gems",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "item",
+            "items": "emerald"
+          },
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "SkyBlock Gems"
+          }
+        ]
       }
     }
   ]

--- a/repo/guis/hotbar/quiver_arrow.json
+++ b/repo/guis/hotbar/quiver_arrow.json
@@ -1,0 +1,105 @@
+{
+  "priority": -1,
+  "target": {
+    "type": "title",
+    "title": "Crafting"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/flint_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Flint Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/reinforced_iron_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Reinforced Iron Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/gold_tipped_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Gold-tipped Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/redstone_tipped_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Redstone-tipped Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/emerald_tipped_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Emerald-tipped Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/bouncy_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Bouncy Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/icy_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Icy Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/armorshred_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Armorshred Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/explosive_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Explosive Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/glue_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Glue Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/nansorb_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Nansorb Arrow"
+      }
+    },
+    {
+      "id": "skyblock_gui:hotbar/quiver/icon/magma_arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver Magma Arrow"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/alchemy/alchemy.json
+++ b/repo/guis/recipe_book/alchemy/alchemy.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Alchemy Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/alchemy/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Alchemy Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/carpentry/carpentry.json
+++ b/repo/guis/recipe_book/carpentry/carpentry.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Carpentry Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/carpentry/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Carpentry Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/enchanting/enchanting.json
+++ b/repo/guis/recipe_book/enchanting/enchanting.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Enchanting Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/enchanting/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Enchanting Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/farming/farming.json
+++ b/repo/guis/recipe_book/farming/farming.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Farming Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/farming/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Farming Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/fishing/fishing.json
+++ b/repo/guis/recipe_book/fishing/fishing.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Fishing Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/fishing/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Fishing Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/foraging/foraging.json
+++ b/repo/guis/recipe_book/foraging/foraging.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Foraging Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/Foraging/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Foraging Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/hunting/hunting.json
+++ b/repo/guis/recipe_book/hunting/hunting.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Hunting Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/hunting/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Hunting Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/mining/mining.json
+++ b/repo/guis/recipe_book/mining/mining.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Mining Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/mining/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Mining Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/recipe_book.json
+++ b/repo/guis/recipe_book/recipe_book.json
@@ -1,0 +1,112 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Recipe Book"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Recipe Book"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/farming/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Farming Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/mining/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Mining Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/combat/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Combat Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/fishing/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Fishing Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/foraging/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Foraging Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/enchanting/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Enchanting Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/alchemy/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Alchemy Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/carpentry/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Carpentry Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/hunting/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Hunting Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/slayer/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/special/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Special Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/trades/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Trades"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/slayer/inferno_demonlord/inferno_demonlord.json
+++ b/repo/guis/recipe_book/slayer/inferno_demonlord/inferno_demonlord.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Inferno Demonlord Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/slayer/inferno_demonlord/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Inferno Demonlord Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/slayer/revenant_horror/revenant_horror.json
+++ b/repo/guis/recipe_book/slayer/revenant_horror/revenant_horror.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Revenant Horror Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/slayer/revenant_horror/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Revenant Horror Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/slayer/slayer.json
+++ b/repo/guis/recipe_book/slayer/slayer.json
@@ -1,0 +1,56 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Slayer Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/slayer/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/slayer/revenant_horror/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Revenant Horror Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/slayer/tarantula_broodfather/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Tarantula Broodfather Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/slayer/sven_packmaster/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Sven Packmaster Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/slayer/voidgloom_seraph/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Voidgloom Seraph Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:recipe_book/slayer/inferno_demonlord/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Inferno Demonlord Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/slayer/sven_packmaster/sven_packmaster.json
+++ b/repo/guis/recipe_book/slayer/sven_packmaster/sven_packmaster.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Sven Packmaster Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/slayer/sven_packmaster/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Sven Packmaster Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/slayer/tarantula_broodfather/tarantula_broodfather.json
+++ b/repo/guis/recipe_book/slayer/tarantula_broodfather/tarantula_broodfather.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Tarantula Broodfather Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/slayer/tarantula_broodfather/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Tarantula Broodfather Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/slayer/voidgloom_seraph/voidgloom_seraph.json
+++ b/repo/guis/recipe_book/slayer/voidgloom_seraph/voidgloom_seraph.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Voidgloom Seraph Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/slayer/voidgloom_seraph/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Voidgloom Seraph Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/recipe_book/special/special.json
+++ b/repo/guis/recipe_book/special/special.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Special Recipes"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:recipe_book/special/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Special Recipes"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/f1/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/f1/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(F1\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f1",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/f1/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/f2/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/f2/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(F2\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f2",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/f2/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/f3/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/f3/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(F3\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f3",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/f3/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/f4/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/f4/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(F4\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f4",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/f4/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/f5/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/f5/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(F5\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f5",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/f5/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/f6/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/f6/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(F6\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f6",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/f6/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/f7/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/f7/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Catacombs \\(F7\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f7",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/f7/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/m1/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/m1/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(M1\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m1",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/m1/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/m2/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/m2/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(M2\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m2",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/m2/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/m3/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/m3/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(M3\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m3",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/m3/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/m4/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/m4/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(M4\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m4",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/m4/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/m5/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/m5/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(M5\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m5",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/m5/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/m6/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/m6/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs \\(M6\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m6",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/m6/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/m7/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/m7/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Catacombs \\(M7\\) RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m7",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/m7/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/catacombs/rng_meter.json
+++ b/repo/guis/rng_meter/catacombs/rng_meter.json
@@ -1,0 +1,282 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Catacombs RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/icon/catacombs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Catacombs RNG Meters"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f1",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (F1)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f2",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (F2)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f3",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (F3)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f4",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (F4)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f5",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (F5)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f6",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (F6)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/f7",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (F7)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m1",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (M1)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m2",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (M2)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m3",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (M3)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m4",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (M4)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m5",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (M5)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m6",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (M6)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/catacombs/icon/m7",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Catacombs (M7)"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/crystal_nucleus/rng_meter.json
+++ b/repo/guis/rng_meter/crystal_nucleus/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Crystal Nucleus RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/icon/crystal_nucleus",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/crystal_nucleus/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/experimentation_table/rng_meter.json
+++ b/repo/guis/rng_meter/experimentation_table/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "\\(\\d+?\\/\\d+?\\) Experimentation Table RNG"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/icon/experimentation_table",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/experimentation_table/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/frozen_corpses/rng_meter.json
+++ b/repo/guis/rng_meter/frozen_corpses/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Frozen Corpses RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/icon/frozem_corpses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/frozen_corpses/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/rng_meter.json
+++ b/repo/guis/rng_meter/rng_meter.json
@@ -1,0 +1,89 @@
+{
+  "target": {
+    "type": "title",
+    "title": "RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/icon/experimentation_table",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Experimentation Table"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/icon/slayer",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer RNG Meters"
+      }
+    },
+    {
+      "id": "skyblock_gui:catacombs_rng_meters/icon/slayer",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Catacombs RNG Meters"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/icon/crystal_nucleus",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Crystal Nucleus"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/icon/frozen_corpses",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Frozen Corpses"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/icon/pity_tracker",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Pity Tracker"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/slayer/inferno_demonlord/rng_meter.json
+++ b/repo/guis/rng_meter/slayer/inferno_demonlord/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Inferno Demonlord RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/inferno_demonlord",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/inferno_demonlord/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/slayer/revenant_horror/rng_meter.json
+++ b/repo/guis/rng_meter/slayer/revenant_horror/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Revenant Horror RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/revenant_horror",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/revenant_horror/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/slayer/rifkstalker_bloodfiend/rng_meter.json
+++ b/repo/guis/rng_meter/slayer/rifkstalker_bloodfiend/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Riftstalker Bloodfiend RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/riftstalker_bloodfiend",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/riftstalker_bloodfiend/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/slayer/rng_meter.json
+++ b/repo/guis/rng_meter/slayer/rng_meter.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Slayer RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/icon/slayer",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer RNG Meters"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/revenant_horror",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "item",
+            "items": "rotten_flesh"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/tarantula_broodfather",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "item",
+            "items": "cobweb"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/sven_packmaster",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "item",
+            "items": "mutton"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/voidgloom_seraph",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "item",
+            "items": "ender_pearl"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/riftstalker_bloodfiend",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "item",
+            "items": "redstone"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/inferno_demonlord",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "RNG Meter"
+          },
+          {
+            "type": "item",
+            "items": "blaze_powder"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/slayer/sven_packmaster/rng_meter.json
+++ b/repo/guis/rng_meter/slayer/sven_packmaster/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Sven Packmaster RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/sven_packmaster",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/sven_packmaster/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/slayer/tarantula_broodfather/rng_meter.json
+++ b/repo/guis/rng_meter/slayer/tarantula_broodfather/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Tarantula Broodfather RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/tarantula_broodfather",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/tarantula_broodfather/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/rng_meter/slayer/voidgloom_seraph/rng_meter.json
+++ b/repo/guis/rng_meter/slayer/voidgloom_seraph/rng_meter.json
@@ -1,0 +1,24 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Voidgloom Seraph RNG Meter"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:rng_meter/slayer/icon/voidgloom_seraph",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    },
+    {
+      "id": "skyblock_gui:rng_meter/slayer/voidgloom_seraph/icon/reset_rng_drop",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Reset RNG Drop"
+      }
+    }
+  ]
+}

--- a/repo/guis/skill_tree/hotm.json
+++ b/repo/guis/skill_tree/hotm.json
@@ -1314,7 +1314,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked",
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_1",
       "target": {
         "type": "all",
         "conditions": [
@@ -1324,8 +1324,181 @@
             "name": "Core of the Mountain"
           },
           {
-            "type": "item",
-            "items": "minecraft:redstone_block"
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 1/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_2",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 2/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_3",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 3/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_4",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 4/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_5",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 5/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_6",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 6/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_7",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 7/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_8",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 8/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_9",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 9/10"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skill_tree/hotm/core_of_the_mountain/unlocked/tier_10",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Core of the Mountain"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": 0,
+            "name": "Level 10"
           }
         ]
       }

--- a/repo/guis/skills/combat/slayer/inferno_demonlord/inferno_demonlord.json
+++ b/repo/guis/skills/combat/slayer/inferno_demonlord/inferno_demonlord.json
@@ -1,0 +1,373 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Inferno Demonlord"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_1/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord II"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier I to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level V!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_2/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord III"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier II to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level X!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_3/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord IV"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier III to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XV!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_4/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord V"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier IV to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XXV!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Inferno Demonlord Slayer 7"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_5/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/tier_5/unimplemented",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Inferno Demonlord V"
+          },
+          {
+            "type": "item",
+            "items": "coal_block"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Leveling Rewards"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/icon/boss_drops",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Drops"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:rngmeter/slayer/icon/inferno_demonlord",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/inferno_demonlord/lvl_rewards/lvl_rewards.json
+++ b/repo/guis/skills/combat/slayer/inferno_demonlord/lvl_rewards/lvl_rewards.json
@@ -1,0 +1,700 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Blaze Slayer LVL Rewards"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_1/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_1/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_1/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_2/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_2/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_3/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_3/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_4/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_4/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_5/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_5/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_6/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_6/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_6/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_6/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_7/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_7/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_7/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_7/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_8/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_8/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_8/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_9/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_9/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_9/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/lvl_9/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Blaze Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/boss_leveling_rewards/icon/more_to_come",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "More to come!"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/revenant_horror/lvl_rewards/lvl_rewards.json
+++ b/repo/guis/skills/combat/slayer/revenant_horror/lvl_rewards/lvl_rewards.json
@@ -1,0 +1,700 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Zombie Slayer LVL Rewards"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_1/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_1/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_1/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_2/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_2/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_3/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_3/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_4/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_4/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_5/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_5/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_6/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_6/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_6/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_6/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_7/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_7/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_7/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_7/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_8/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_8/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_8/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_9/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_9/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_9/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/lvl_9/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Zombie Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/boss_leveling_rewards/icon/more_to_come",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "More to come!"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/revenant_horror/revenant_horror.json
+++ b/repo/guis/skills/combat/slayer/revenant_horror/revenant_horror.json
@@ -1,0 +1,356 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Revenant Horror"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_1/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror II"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier I to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level V!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_2/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror III"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier II to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level X!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_3/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror IV"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier III to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XV!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_4/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror V"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier IV to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XXV!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Revenant Horror Slayer 7"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/tier_5/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Revenant Horror V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Leveling Rewards"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/icon/boss_drops",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Drops"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:rngmeter/slayer/icon/revenant_horror",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/riftstalker_bloodfiend/lvl_rewards/lvl_rewards.json
+++ b/repo/guis/skills/combat/slayer/riftstalker_bloodfiend/lvl_rewards/lvl_rewards.json
@@ -1,0 +1,396 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Vampire Slayer LVL Rewards"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_1/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_1/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_1/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_2/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_2/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_3/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_3/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_4/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_4/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_5/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_5/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/lvl_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Vampire Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/boss_leveling_rewards/icon/more_to_come",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "More to come!"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/riftstalker_bloodfiend/riftstalker_bloodfiend.json
+++ b/repo/guis/skills/combat/slayer/riftstalker_bloodfiend/riftstalker_bloodfiend.json
@@ -1,0 +1,356 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Riftstalker Bloodfiend"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_1/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend II"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier I to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level V!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_2/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend III"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier II to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level X!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_3/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend IV"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier III to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XV!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_4/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend V"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier IV to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XXV!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Riftstalker Bloodfiend Slayer 7"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/tier_5/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Riftstalker Bloodfiend V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Leveling Rewards"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/icon/boss_drops",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Drops"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:rngmeter/slayer/icon/riftstalker_bloodfiend",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/slayer.json
+++ b/repo/guis/skills/combat/slayer/slayer.json
@@ -1,0 +1,350 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Slayer"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Revenant Horror"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to view boss!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/revenant_horror/icon/rift",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Revenant Horror"
+          },
+          {
+            "type": "item",
+            "items": "nether_wart"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Tarantula Broodfather"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to view boss!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/icon/rift",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Tarantula Broodfather"
+          },
+          {
+            "type": "item",
+            "items": "nether_wart"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Sven Packmaster"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Slay Tarantula Broodfather II!"
+          }
+        ]
+      }
+    },
+
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Sven Packmaster"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to view boss!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/icon/rift",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Sven Packmaster"
+          },
+          {
+            "type": "item",
+            "items": "nether_wart"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Voidgloom Seraph"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Slay Sven Packmaster IV!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Voidgloom Seraph"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to view boss!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/icon/rift",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Voidgloom Seraph"
+          },
+          {
+            "type": "item",
+            "items": "nether_wart"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/icon/overworld",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Riftstalker Bloodfiend"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Only inside The Rift!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/riftstalker_bloodfiend/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Riftstalker Bloodfiend"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to view boss!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Inferno Demonlord"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Slay Voidgloom Seraph III!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Inferno Demonlord"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to view boss!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/inferno_demonlord/icon/rift",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "☠ Inferno Demonlord"
+          },
+          {
+            "type": "item",
+            "items": "nether_wart"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/icon/unreleased",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Not released yet!"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/auto_slayer/icon/disabled",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Auto-Slayer"
+          },
+          {
+            "type": "item",
+            "items": ["minecraft:gray_dye"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/auto_slayer/icon/enabled",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Auto-Slayer"
+          },
+          {
+            "type": "item",
+            "items": ["minecraft:lime_dye"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/icon/slayer_leaderboards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Leaderboards"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/icon/global_combat_wisdom_buff",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Global Combat Wisdom Buff"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/icon/slayer_bonus_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Bonus Rewards"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/sven_packmaster/lvl_rewards/lvl_rewards.json
+++ b/repo/guis/skills/combat/slayer/sven_packmaster/lvl_rewards/lvl_rewards.json
@@ -1,0 +1,700 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Wolf Slayer LVL Rewards"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_1/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_1/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_1/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_2/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_2/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_3/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_3/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_4/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_4/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_5/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_5/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_6/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_6/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_6/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_6/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_7/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_7/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_7/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_7/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_8/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_8/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_8/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_9/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_9/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_9/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/lvl_9/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Wolf Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/boss_leveling_rewards/icon/more_to_come",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "More to come!"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/sven_packmaster/sven_packmaster.json
+++ b/repo/guis/skills/combat/slayer/sven_packmaster/sven_packmaster.json
@@ -1,0 +1,373 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Sven Packmaster"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_1/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster II"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier I to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level V!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_2/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster III"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier II to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level X!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_3/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster IV"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier III to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XV!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_4/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster V"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier IV to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XXV!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Sven Packmaster Slayer 7"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_5/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/tier_5/unimplemented",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Sven Packmaster V"
+          },
+          {
+            "type": "item",
+            "items": "coal_block"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Leveling Rewards"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/icon/boss_drops",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Drops"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/sven_packmaster/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:rngmeter/slayer/icon/sven_packmaster",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/tarantula_broodfather/lvl_rewards/lvl_rewards.json
+++ b/repo/guis/skills/combat/slayer/tarantula_broodfather/lvl_rewards/lvl_rewards.json
@@ -1,0 +1,700 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Spider Slayer LVL Rewards"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_1/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_1/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_1/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_2/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_2/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_3/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_3/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_4/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_4/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_5/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_5/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_6/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_6/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_6/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_6/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_7/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_7/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_7/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_7/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_8/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_8/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_8/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_9/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_9/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_9/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/lvl_9/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Spider Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantul_broodfather/boss_leveling_rewards/icon/more_to_come",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "More to come!"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/tarantula_broodfather/tarantula_broodfather.json
+++ b/repo/guis/skills/combat/slayer/tarantula_broodfather/tarantula_broodfather.json
@@ -1,0 +1,356 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Tarantula Broodfather"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_1/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather II"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier I to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level V!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_2/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather III"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier II to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level X!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_3/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather IV"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier III to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XV!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_4/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather V"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier IV to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XXV!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Tarantula Broodfather Slayer 7"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/tier_5/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Tarantula Broodfather V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Leveling Rewards"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/icon/boss_drops",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Drops"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/tarantula_broodfather/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:rngmeter/slayer/icon/tarantula_broodfather",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/voidgloom_seraph/lvl_rewards/lvl_rewards.json
+++ b/repo/guis/skills/combat/slayer/voidgloom_seraph/lvl_rewards/lvl_rewards.json
@@ -1,0 +1,700 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Enderman Slayer LVL Rewards"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_1/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_1/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_1/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 1"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_2/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_2/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 2"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_3/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_3/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 3"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_4/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_4/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 4"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_5/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_5/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_6/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_6/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_6/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_6/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 6"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_7/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_7/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_7/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_7/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 7"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 5"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_8/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_8/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_8/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 8"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_9/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -2,
+            "name": "Reward is secret!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_9/icon/unlocking",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Level not reached!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_9/icon/claimable",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to claim rewards!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/lvl_9/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Enderman Slayer LVL 9"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Rewards claimed!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/boss_leveling_rewards/icon/more_to_come",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "More to come!"
+      }
+    }
+  ]
+}

--- a/repo/guis/skills/combat/slayer/voidgloom_seraph/voidgloom_seraph.json
+++ b/repo/guis/skills/combat/slayer/voidgloom_seraph/voidgloom_seraph.json
@@ -1,0 +1,373 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Voidgloom Seraph"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_1/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_1/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph I"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_2/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph II"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier I to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level V!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_2/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_2/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph II"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_3/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph III"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier II to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level X!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_3/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_3/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph III"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_4/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph IV"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier III to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XV!"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_4/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_4/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph IV"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_5/icon/locked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph V"
+          },
+          {
+            "type": "any",
+            "conditions": [
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Slay Tier IV to unlock!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Combat Level XXV!"
+              },
+              {
+                "type": "lore",
+                "mode": "equals",
+                "line": -1,
+                "name": "Requires Voidgloom Seraph Slayer 7"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_5/icon/unlocked",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Click to slay!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_5/icon/expensive",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph V"
+          },
+          {
+            "type": "lore",
+            "mode": "equals",
+            "line": -1,
+            "name": "Cannot afford quest!"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/tier_5/unimplemented",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "name",
+            "mode": "equals",
+            "name": "Voidgloom Seraph V"
+          },
+          {
+            "type": "item",
+            "items": "coal_block"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Leveling Rewards"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/icon/boss_drops",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Boss Drops"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/slayer/voidgloom_seraph/icon/boss_leveling_rewards",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Slayer Recipes"
+      }
+    },
+    {
+      "id": "skyblock_gui:rngmeter/slayer/icon/voidgloom_seraph",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "RNG Meter"
+      }
+    }
+  ]
+}

--- a/repo/guis/skyblock_menu/calendar.json
+++ b/repo/guis/skyblock_menu/calendar.json
@@ -5,35 +5,35 @@
   },
   "layout": [
     {
-      "id": "skyblock_gui:calendar/current_day",
+      "id": "skyblock_gui:calendar_and_events/calendar/current_day",
       "target": {
         "type": "item",
         "items": "minecraft:lime_dye"
       }
     },
     {
-      "id": "skyblock_gui:calendar/other_day",
+      "id": "skyblock_gui:calendar_and_events/calendar/other_day",
       "target": {
         "type": "item",
         "items": "minecraft:paper"
       }
     },
     {
-      "id": "skyblock_gui:calendar/farming_contest",
+      "id": "skyblock_gui:calendar_and_events/calendar/farming_contest",
       "target": {
         "type": "item",
         "items": "minecraft:wheat"
       }
     },
     {
-      "id": "skyblock_gui:calendar/dark_auction",
+      "id": "skyblock_gui:calendar_and_events/calendar/dark_auction",
       "target": {
         "type": "item",
         "items": "minecraft:nether_brick"
       }
     },
     {
-      "id": "skyblock_gui:calendar/hoppity",
+      "id": "skyblock_gui:calendar_and_events/calendar/hoppity",
       "target": {
         "type": "all",
         "conditions": [
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "skyblock_gui:calendar/traveling_zoo",
+      "id": "skyblock_gui:calendar_and_events/calendar/traveling_zoo",
       "target": {
         "type": "all",
         "conditions": [
@@ -65,28 +65,28 @@
       }
     },
     {
-      "id": "skyblock_gui:calendar/spooky",
+      "id": "skyblock_gui:calendar_and_events/calendar/spooky",
       "target": {
         "type": "item",
         "items": "minecraft:jack_o_lantern"
       }
     },
     {
-      "id": "skyblock_gui:calendar/workshop_opens",
+      "id": "skyblock_gui:calendar_and_events/calendar/workshop_opens",
       "target": {
         "type": "item",
         "items": "minecraft:snow_block"
       }
     },
     {
-      "id": "skyblock_gui:calendar/season_of_jerry",
+      "id": "skyblock_gui:calendar_and_events/calendar/season_of_jerry",
       "target": {
         "type": "item",
         "items": "minecraft:snowball"
       }
     },
     {
-      "id": "skyblock_gui:calendar/new_year",
+      "id": "skyblock_gui:calendar_and_events/calendar/new_year",
       "target": {
         "type": "item",
         "items": "minecraft:cake"

--- a/repo/guis/skyblock_menu/calendar_and_events.json
+++ b/repo/guis/skyblock_menu/calendar_and_events.json
@@ -5,7 +5,7 @@
   },
   "layout": [
     {
-      "id": "skyblock_gui:calendar_and_events/event_rewards",
+      "id": "skyblock_gui:calendar_and_events/event_rewards/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "skyblock_gui:calendar/icon",
+      "id": "skyblock_gui:calendar_and_events/calendar/icon",
       "target": {
         "type": "name",
         "mode": "equals",

--- a/repo/guis/skyblock_menu/skyblock_menu.json
+++ b/repo/guis/skyblock_menu/skyblock_menu.json
@@ -5,7 +5,7 @@
   },
   "layout": [
     {
-      "id": "skyblock_gui:garden_desk",
+      "id": "skyblock_gui:garden_desk/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -29,7 +29,7 @@
       }
     },
     {
-      "id": "skyblock_gui:manage_chips",
+      "id": "skyblock_gui:manage_chips/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -37,7 +37,7 @@
       }
     },
     {
-      "id": "skyblock_gui:your_skyblock_profile",
+      "id": "skyblock_gui:your_skyblock_profile/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "skyblock_gui:recipe_book",
+      "id": "skyblock_gui:recipe_book/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -69,7 +69,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skyblock_leveling",
+      "id": "skyblock_gui:skyblock_leveling/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "id": "skyblock_gui:quests_and_chapters",
+      "id": "skyblock_gui:quests_and_chapters/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "skyblock_gui:calendar_and_events",
+      "id": "skyblock_gui:calendar_and_events/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "skyblock_gui:your_bags",
+      "id": "skyblock_gui:your_bags/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -117,7 +117,7 @@
       }
     },
     {
-      "id": "skyblock_gui:pets",
+      "id": "skyblock_gui:pets/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -125,7 +125,7 @@
       }
     },
     {
-      "id": "skyblock_gui:crafting_table",
+      "id": "skyblock_gui:crafting_table/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "skyblock_gui:rift_guide",
+      "id": "skyblock_gui:rift_guide/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -149,7 +149,7 @@
       }
     },
     {
-      "id": "skyblock_gui:personal_bank",
+      "id": "skyblock_gui:personal_bank/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -157,7 +157,7 @@
       }
     },
     {
-      "id": "skyblock_gui:fast_travel",
+      "id": "skyblock_gui:fast_travel/icon",
       "target": {
         "type": "name",
         "mode": "equals",
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "skyblock_gui:profile_management",
+      "id": "skyblock_gui:profile_management/icon",
       "target": {
         "type": "name",
         "mode": "equals",

--- a/repo/guis/stats/combat/ability_damage/stats.json
+++ b/repo/guis/stats/combat/ability_damage/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Ability Damage"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/ability_damage/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "๑ Ability Damage.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:beacon"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ability_damage/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "๑ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ability_damage/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ability_damage/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "๑ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ability_damage/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "๑ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ability_damage/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "๑ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/bonus_attack_speed/stats.json
+++ b/repo/guis/stats/combat/bonus_attack_speed/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Bonus Attack Speed"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/bonus_attack_speed/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⚔ Bonus Attack Speed.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_axe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/bonus_attack_speed/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚔ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/bonus_attack_speed/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/bonus_attack_speed/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚔ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/bonus_attack_speed/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚔ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/bonus_attack_speed/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚔ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/crit_chance/stats.json
+++ b/repo/guis/stats/combat/crit_chance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Crit Chance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/crit_chance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☣ Crit Chance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_chance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☣ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_chance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_chance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☣ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_chance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☣ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_chance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☣ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/crit_damage/stats.json
+++ b/repo/guis/stats/combat/crit_damage/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Crit Damage"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/crit_damage/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☠ Crit Damage.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_damage/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_damage/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_damage/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_damage/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/crit_damage/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/defense/stats.json
+++ b/repo/guis/stats/combat/defense/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Defense"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/defense/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❈ Defense.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:iron_chestplate"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/defense/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❈ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/defense/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/defense/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❈ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/defense/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❈ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/defense/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❈ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/ferocity/stats.json
+++ b/repo/guis/stats/combat/ferocity/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Ferocity"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/ferocity/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⫽ Ferocity.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:red_dye"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ferocity/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⫽ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ferocity/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ferocity/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⫽ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ferocity/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⫽ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/ferocity/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⫽ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/health/stats.json
+++ b/repo/guis/stats/combat/health/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Health"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/health/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❤ Health.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_apple"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/health_regen/stats.json
+++ b/repo/guis/stats/combat/health_regen/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Health Regen"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/health_regen/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❣ Health Regen.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:potion"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health_regen/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❣ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health_regen/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health_regen/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❣ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health_regen/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❣ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/health_regen/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❣ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/intelligence/stats.json
+++ b/repo/guis/stats/combat/intelligence/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Intelligence"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/intelligence/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "✎ Intelligence.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:enchanted_book"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/intelligence/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✎ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/intelligence/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/intelligence/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✎ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/intelligence/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✎ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/intelligence/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✎ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/mending/stats.json
+++ b/repo/guis/stats/combat/mending/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mending"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/mending/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☄ Mending.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:ghast_tear"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/mending/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☄ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/mending/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/mending/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☄ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/mending/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☄ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/mending/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☄ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/strength/stats.json
+++ b/repo/guis/stats/combat/strength/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Strength"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/strength/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❁ Strength.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:blaze_powder"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/strength/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/strength/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/strength/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/strength/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/strength/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/swing_range/stats.json
+++ b/repo/guis/stats/combat/swing_range/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Swing Range"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/swing_range/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "Ⓢ Swing Range.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:stone_sword"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/swing_range/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓢ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/swing_range/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/swing_range/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓢ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/swing_range/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓢ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/swing_range/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓢ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/true_defense/stats.json
+++ b/repo/guis/stats/combat/true_defense/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ True Defense"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/true_defense/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❂ True Defense.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:bone_meal"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/true_defense/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❂ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/true_defense/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/true_defense/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❂ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/true_defense/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❂ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/true_defense/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❂ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/combat/vitality/stats.json
+++ b/repo/guis/stats/combat/vitality/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Vitality"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/combat/vitality/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "♨ Vitality.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_apple"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/vitality/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/vitality/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/vitality/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/vitality/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/combat/vitality/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/bonus_pest_chance/stats.json
+++ b/repo/guis/stats/farming/bonus_pest_chance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Bonus Pest Chance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/bonus_pest_chance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "ൠ Bonus Pest Chance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:dirt"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/bonus_pest_chance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ൠ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/bonus_pest_chance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/bonus_pest_chance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ൠ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/bonus_pest_chance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ൠ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/bonus_pest_chance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ൠ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/cactus_fortune/stats.json
+++ b/repo/guis/stats/farming/cactus_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Cactus Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/cactus_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Cactus Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:cactus"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cactus_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cactus_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cactus_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cactus_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cactus_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/carrot_fortune/stats.json
+++ b/repo/guis/stats/farming/carrot_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Carrot Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/carrot_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Carrot Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:carrot"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/carrot_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/carrot_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/carrot_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/carrot_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/carrot_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/cocoa_beans_fortune/stats.json
+++ b/repo/guis/stats/farming/cocoa_beans_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Cocoa Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/cocoa_beans_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Cocoa Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:cocoa_beans"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cocoa_beans_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cocoa_beans_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cocoa_beans_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cocoa_beans_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/cocoa_beans_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/farming_fortune/stats.json
+++ b/repo/guis/stats/farming/farming_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Farming Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/farming_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Farming Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/farming_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/farming_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/farming_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/farming_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/farming_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/melon_fortune/stats.json
+++ b/repo/guis/stats/farming/melon_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Melon Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/melon_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Melon Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/melon_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/melon_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/melon_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/melon_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/melon_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/moonflower_fortune/stats.json
+++ b/repo/guis/stats/farming/moonflower_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Moonflower Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/moonflower_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Moonflower Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:blue_orchid"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/moonflower_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/moonflower_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/moonflower_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/moonflower_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/moonflower_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/mushroom_fortune/stats.json
+++ b/repo/guis/stats/farming/mushroom_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mushroom Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/mushroom_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Mushroom Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:red_mushroom"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/mushroom_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/mushroom_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/mushroom_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/mushroom_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/mushroom_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/nether_wart_fortune/stats.json
+++ b/repo/guis/stats/farming/nether_wart_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Nether Wart Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/nether_wart_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Nether Wart Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:nether_wart"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/nether_wart_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/nether_wart_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/nether_wart_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/nether_wart_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/nether_wart_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/potato_fortune/stats.json
+++ b/repo/guis/stats/farming/potato_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Potato Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/potato_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Potato Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:potato"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/potato_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/potato_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/potato_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/potato_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/potato_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/pumpkin_fortune/stats.json
+++ b/repo/guis/stats/farming/pumpkin_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Pumpkin Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/pumpkin_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Pumpkin Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:carved_pumpkin"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/pumpkin_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/pumpkin_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/pumpkin_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/pumpkin_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/pumpkin_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/sugar_cane_fortune/stats.json
+++ b/repo/guis/stats/farming/sugar_cane_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Sugar Cane Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/sugar_cane_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Sugar Cane Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:sugar_cane"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sugar_cane_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sugar_cane_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sugar_cane_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sugar_cane_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sugar_cane_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/sunflower_fortune/stats.json
+++ b/repo/guis/stats/farming/sunflower_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Sunflower Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/sunflower_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Sunflower Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:sunflower"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sunflower_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sunflower_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sunflower_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sunflower_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/sunflower_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/wheat_fortune/stats.json
+++ b/repo/guis/stats/farming/wheat_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Wheat Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/wheat_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Wheat Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:wheat"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wheat_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wheat_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wheat_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wheat_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wheat_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/farming/wild_rose_fortune/stats.json
+++ b/repo/guis/stats/farming/wild_rose_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Wild Rose Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/farming/wild_rose_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Wild Rose Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:rose_bush"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wild_rose_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wild_rose_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wild_rose_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wild_rose_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/farming/wild_rose_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/fishing/double_hook_chance/stats.json
+++ b/repo/guis/stats/fishing/double_hook_chance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Double Hook Chance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/fishing/double_hook_chance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⚓ Double Hook Chance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:cooked_cod"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/double_hook_chance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚓ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/double_hook_chance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/double_hook_chance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚓ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/double_hook_chance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚓ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/double_hook_chance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚓ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/fishing/fishing_speed/stats.json
+++ b/repo/guis/stats/fishing/fishing_speed/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Fishing Speed"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/fishing/fishing_speed/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☂ Fishing Speed.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:fishing_rod"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/fishing_speed/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☂ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/fishing_speed/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/fishing_speed/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☂ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/fishing_speed/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☂ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/fishing_speed/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☂ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/fishing/sea_creature_chance/stats.json
+++ b/repo/guis/stats/fishing/sea_creature_chance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Sea Creature Chance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/fishing/sea_creature_chance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "α Sea Creature Chance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:prismarine_crystals"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/sea_creature_chance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "α Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/sea_creature_chance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/sea_creature_chance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "α Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/sea_creature_chance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "α Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/sea_creature_chance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "α Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/fishing/treasure_chance/stats.json
+++ b/repo/guis/stats/fishing/treasure_chance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Treasure Chance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/fishing/treasure_chance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⛃ Treasure Chance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:chest"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/treasure_chance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⛃ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/treasure_chance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/treasure_chance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⛃ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/treasure_chance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⛃ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/treasure_chance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⛃ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/fishing/trophy_fish_chance/stats.json
+++ b/repo/guis/stats/fishing/trophy_fish_chance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Trophy Fish Chance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/fishing/trophy_fish_chance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "♔ Trophy Fish Chance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/trophy_fish_chance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♔ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/trophy_fish_chance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/trophy_fish_chance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♔ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/trophy_fish_chance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♔ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/trophy_fish_chance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♔ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/foraging/fig_fortune/stats.json
+++ b/repo/guis/stats/foraging/fig_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Fig Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/foraging/fig_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Fig Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:stripped_spruce_log"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/fig_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/fig_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/fig_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/fig_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/fig_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/foraging/foraging_fortune/stats.json
+++ b/repo/guis/stats/foraging/foraging_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Foraging Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/foraging/foraging_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Foraging Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/foraging_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/foraging_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/foraging_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/foraging_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/fishing/foraging_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/foraging/mangrove_fortune/stats.json
+++ b/repo/guis/stats/foraging/mangrove_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mangrove Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/foraging/mangrove_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Mangrove Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:mangrove_log"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/mangrove_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/mangrove_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/mangrove_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/mangrove_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/mangrove_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/foraging/sweep/stats.json
+++ b/repo/guis/stats/foraging/sweep/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Sweep"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/foraging/sweep/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "∮ Sweep.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:diamond_axe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/sweep/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "∮ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/sweep/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/sweep/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "∮ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/sweep/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "∮ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/foraging/sweep/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "∮ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/hunting/hunting_fortune/stats.json
+++ b/repo/guis/stats/hunting/hunting_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Hunting Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/hunting/hunting_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Hunting Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:prismarine_shard"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/hunting_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/hunting_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/hunting_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/hunting_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/hunting_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/hunting/pull/stats.json
+++ b/repo/guis/stats/hunting/pull/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Pull"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/hunting/pull/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "ᛷ Pull.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:cobweb"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/pull/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ᛷ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/pull/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/pull/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ᛷ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/pull/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ᛷ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/hunting/pull/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ᛷ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/block_fortune/stats.json
+++ b/repo/guis/stats/mining/block_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Block Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/block_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Block Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/block_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/block_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/block_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/block_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/block_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/breaking_power/stats.json
+++ b/repo/guis/stats/mining/breaking_power/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Breaking Power"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "Ⓟ Breaking Power.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:emerald"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/dwarven_metal_fortune/stats.json
+++ b/repo/guis/stats/mining/dwarven_metal_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Dwarven Metal Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/dwarven_metal_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Dwarven Metal Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/dwarven_metal_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/dwarven_metal_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/dwarven_metal_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/dwarven_metal_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/dwarven_metal_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/gemstone_fortune/stats.json
+++ b/repo/guis/stats/mining/gemstone_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Gemstone Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Gemstone Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/gemstone_spread/stats.json
+++ b/repo/guis/stats/mining/gemstone_spread/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Gemstone Spread"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "▚ Gemstone Spread.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_pickaxe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/mining_fortune/stats.json
+++ b/repo/guis/stats/mining/mining_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mining Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/mining_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Mining Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/mining_speed/stats.json
+++ b/repo/guis/stats/mining/mining_speed/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mining Speed"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⸕ Mining Speed.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:diamond_pickaxe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/mining_spread/stats.json
+++ b/repo/guis/stats/mining/mining_spread/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mining Spread"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "▚ Mining Spread.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_pickaxe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/ore_fortune/stats.json
+++ b/repo/guis/stats/mining/ore_fortune/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Ore Fortune"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/ore_fortune/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☘ Ore Fortune.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/ore_fortune/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/ore_fortune/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/ore_fortune/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/ore_fortune/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/ore_fortune/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☘ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/mining/pristine/stats.json
+++ b/repo/guis/stats/mining/pristine/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Pristine"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/pristine/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "✧ Pristine.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/breaking_power/stats.json
+++ b/repo/guis/stats/miscellaneous/breaking_power/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Breaking Power"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "Ⓟ Breaking Power.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:emerald"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/breaking_power/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Ⓟ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/cold_resistance/stats.json
+++ b/repo/guis/stats/miscellaneous/cold_resistance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Cold Resistance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/cold_resistance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❄ Cold Resistance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:ice"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/cold_resistance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❄ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/cold_resistance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/cold_resistance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❄ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/cold_resistance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❄ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/cold_resistance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❄ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/fear/stats.json
+++ b/repo/guis/stats/miscellaneous/fear/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Fear"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/fear/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☠ Fear.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:cauldron"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/fear/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/fear/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/fear/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/fear/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/fear/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☠ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/gemstone_spread/stats.json
+++ b/repo/guis/stats/miscellaneous/gemstone_spread/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Gemstone Spread"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "▚ Gemstone Spread.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_pickaxe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/gemstone_spread/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/heat_resistance/stats.json
+++ b/repo/guis/stats/miscellaneous/heat_resistance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Heat Resistance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/heat_resistance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "♨ Heat Resistance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:lava_bucket"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/heat_resistance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/heat_resistance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/heat_resistance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/heat_resistance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/heat_resistance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♨ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/magic_find/stats.json
+++ b/repo/guis/stats/miscellaneous/magic_find/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Magic Find"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/magic_find/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "✯ Magic Find.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:stick"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/magic_find/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/magic_find/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/magic_find/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/magic_find/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/magic_find/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/mining_speed/stats.json
+++ b/repo/guis/stats/miscellaneous/mining_speed/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mining Speed"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⸕ Mining Speed.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:diamond_pickaxe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_speed/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⸕ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/mining_spread/stats.json
+++ b/repo/guis/stats/miscellaneous/mining_spread/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mining Spread"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "▚ Mining Spread.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_pickaxe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/mining_spread/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "▚ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/pet_luck/stats.json
+++ b/repo/guis/stats/miscellaneous/pet_luck/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Pet Luck"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pet_luck/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "♣ Pet Luck.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pet_luck/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♣ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pet_luck/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pet_luck/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♣ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pet_luck/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♣ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pet_luck/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "♣ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/pressure_resistance/stats.json
+++ b/repo/guis/stats/miscellaneous/pressure_resistance/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Pressure Resistance"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pressure_resistance/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❍ Pressure Resistance.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:glass_bottle"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pressure_resistance/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❍ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pressure_resistance/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pressure_resistance/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❍ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pressure_resistance/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❍ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/pressure_resistance/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❍ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/pristine/stats.json
+++ b/repo/guis/stats/miscellaneous/pristine/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Pristine"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/mining/pristine/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "✧ Pristine.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:player_head"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/mining/pristine/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✧ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/respiration/stats.json
+++ b/repo/guis/stats/miscellaneous/respiration/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Respiration"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/respiration/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⚶ Respiration.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:glass_bottle"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/respiration/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚶ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/respiration/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/respiration/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚶ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/respiration/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚶ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/respiration/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚶ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/speed/stats.json
+++ b/repo/guis/stats/miscellaneous/speed/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Speed"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/speed/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "✦ Speed.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:sugar"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/speed/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✦ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/speed/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/speed/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✦ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/speed/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✦ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/speed/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "✦ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/miscellaneous/tracking/stats.json
+++ b/repo/guis/stats/miscellaneous/tracking/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Tracking"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/miscellaneous/tracking/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❃ Tracking.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:compass"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/tracking/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❃ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/tracking/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/tracking/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❃ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/tracking/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❃ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/miscellaneous/tracking/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❃ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/rift/hearts/stats.json
+++ b/repo/guis/stats/rift/hearts/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Hearts"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/rift/hearts/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❤ Hearts.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:apple"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/hearts/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/hearts/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/hearts/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/hearts/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/hearts/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❤ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/rift/mana_regen/stats.json
+++ b/repo/guis/stats/rift/mana_regen/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mana Regen"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/rift/mana_regen/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "⚡ Mana Regen.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:diamond"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/mana_regen/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚡ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/mana_regen/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/mana_regen/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚡ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/mana_regen/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚡ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/mana_regen/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "⚡ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/rift/rift_damage/stats.json
+++ b/repo/guis/stats/rift/rift_damage/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Rift Damage"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/rift/rift_damage/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "❁ Rift Damage.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:diamond_sword"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_damage/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_damage/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_damage/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_damage/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_damage/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "❁ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/rift/rift_time/stats.json
+++ b/repo/guis/stats/rift/rift_time/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Rift Time"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/rift/rift_time/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "ф Rift Time.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:clock"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_time/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ф Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_time/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_time/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ф Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_time/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ф Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/rift/rift_time/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "ф Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/alchemy/stats.json
+++ b/repo/guis/stats/wisdom/alchemy/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Alchemy Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/alchemy/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Alchemy Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:brewing_stand"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/alchemy/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/alchemy/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/alchemy/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/alchemy/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/alchemy/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/carpentry/stats.json
+++ b/repo/guis/stats/wisdom/carpentry/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Carpentry Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/carpentry/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Carpentry Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:crafting_table"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/carpentry/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/carpentry/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/carpentry/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/carpentry/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/carpentry/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/combat/stats.json
+++ b/repo/guis/stats/wisdom/combat/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Combat Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/combat/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Combat Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:stone_sword"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/combat/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/combat/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/combat/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/combat/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/combat/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/enchanting/stats.json
+++ b/repo/guis/stats/wisdom/enchanting/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Enchanting Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/enchanting/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Enchanting Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:enchanting_table"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/enchanting/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/enchanting/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/enchanting/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/enchanting/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/enchanting/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/farming/stats.json
+++ b/repo/guis/stats/wisdom/farming/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Farming Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/farming/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Farming Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:golden_hoe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/farming/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/farming/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/farming/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/farming/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/farming/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/fishing/stats.json
+++ b/repo/guis/stats/wisdom/fishing/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Fishing Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/fishing/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Fishing Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:fishing_rod"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/fishing/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/fishing/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/fishing/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/fishing/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/fishing/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/foraging/stats.json
+++ b/repo/guis/stats/wisdom/foraging/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Foraging Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/foraging/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Foraging Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:jungle_sapling"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/foraging/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/foraging/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/foraging/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/foraging/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/foraging/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/hunting/stats.json
+++ b/repo/guis/stats/wisdom/hunting/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Hunting Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/hunting/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Hunting Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:crafting_table"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/hunting/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/hunting/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/hunting/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/hunting/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/hunting/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/mining/stats.json
+++ b/repo/guis/stats/wisdom/mining/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Mining Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/mining/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Mining Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:stone_pickaxe"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/mining/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/mining/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/mining/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/mining/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/mining/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/runecrafting/stats.json
+++ b/repo/guis/stats/wisdom/runecrafting/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Runecrafting Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/runecrafting/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Runecrafting Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:magma_cream"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/runecrafting/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/runecrafting/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/runecrafting/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/runecrafting/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/runecrafting/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/social/stats.json
+++ b/repo/guis/stats/wisdom/social/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Social Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/social/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Social Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:emerald"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/social/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/social/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/social/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/social/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/social/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/stats/wisdom/taming/stats.json
+++ b/repo/guis/stats/wisdom/taming/stats.json
@@ -1,0 +1,64 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Stats ➜ Taming Wisdom"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:stats/wisdom/taming/icon",
+      "target": {
+        "type": "all",
+        "conditions": [
+          {
+            "type": "catharsis:name",
+            "name": "☯ Taming Wisdom.+"
+          },
+          {
+            "type": "item",
+            "items": "minecraft:polar_bear_spawn_egg"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/taming/flat_bonuses",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Flat Bonuses"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/taming/arrow",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "➭"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/taming/additive_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Additive Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/taming/multiplicative_buffs",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Multiplicative Buffs"
+      }
+    },
+    {
+      "id": "skyblock_gui:stats/wisdom/taming/cap",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "☯ Cap"
+      }
+    }
+  ]
+}

--- a/repo/guis/your_bags/quiver/quiver.json
+++ b/repo/guis/your_bags/quiver/quiver.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Quiver"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:your_bags/quiver/clear/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Clear Quiver"
+      }
+    }
+  ]
+}

--- a/repo/guis/your_bags/time_pocket/upgrade_time_pocket.json
+++ b/repo/guis/your_bags/time_pocket/upgrade_time_pocket.json
@@ -1,0 +1,16 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Time Pocket"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:your_bags/time_pocket/upgrade/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Upgrade Time Pocket"
+      }
+    }
+  ]
+}

--- a/repo/guis/your_bags/your_bags.json
+++ b/repo/guis/your_bags/your_bags.json
@@ -1,0 +1,56 @@
+{
+  "target": {
+    "type": "title",
+    "title": "Your Bags"
+  },
+  "layout": [
+    {
+      "id": "skyblock_gui:your_bags/sack_of_sacks/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Sack of Sacks"
+      }
+    },
+    {
+      "id": "skyblock_gui:your_bags/fishing_bag/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Fishing Bag"
+      }
+    },
+    {
+      "id": "skyblock_gui:your_bags/potion_bag/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Potion Bag"
+      }
+    },
+    {
+      "id": "skyblock_gui:your_bags/quiver/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Quiver"
+      }
+    },
+    {
+      "id": "skyblock_gui:your_bags/accessory_bag/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Accessory Bag"
+      }
+    },
+    {
+      "id": "skyblock_gui:your_bags/time_pocket/icon",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Time Pocket"
+      }
+    }
+  ]
+}

--- a/src/catharsis.accesswidener
+++ b/src/catharsis.accesswidener
@@ -2,11 +2,18 @@ classTweaker v1 named
 accessible class net/minecraft/client/multiplayer/ClientChunkCache$Storage
 accessible method net/minecraft/client/renderer/GameRenderer pick (Lnet/minecraft/world/entity/Entity;DDF)Lnet/minecraft/world/phys/HitResult;
 accessible field net/minecraft/client/model/PlayerCapeModel cape Lnet/minecraft/client/model/geom/ModelPart;
+accessible field net/minecraft/client/model/player/PlayerModel slim Z
+accessible field net/minecraft/client/model/PlayerModel slim Z
 accessible field net/minecraft/client/multiplayer/ClientChunkCache storage Lnet/minecraft/client/multiplayer/ClientChunkCache$Storage;
 accessible field net/minecraft/client/multiplayer/ClientChunkCache$Storage chunks Ljava/util/concurrent/atomic/AtomicReferenceArray;
 
+extendable class net/minecraft/client/model/geom/ModelPart
+accessible field net/minecraft/client/model/geom/ModelPart children Ljava/util/Map;
+accessible field net/minecraft/client/model/geom/ModelPart cubes Ljava/util/List;
+
 inject-interface net/minecraft/client/gui/screens/packs/PackSelectionModel$EntryBase me/owdding/catharsis/hooks/pack/PackEntryHook
 inject-interface net/minecraft/client/renderer/item/properties/select/SelectItemModelProperty$Type me/owdding/catharsis/hooks/armor/SelectItemModelPropertyTypeHook
+inject-interface net/minecraft/client/renderer/entity/state/EntityRenderState me/owdding/catharsis/hooks/entity/EntityRenderStateHook
 inject-interface net/minecraft/client/renderer/entity/state/LivingEntityRenderState me/owdding/catharsis/hooks/armor/LivingEntityRenderStateHook
 inject-interface net/minecraft/client/renderer/item/ItemStackRenderState me/owdding/catharsis/hooks/items/ItemStackRenderStateHook
 inject-interface net/minecraft/client/resources/model/ModelManager me/owdding/catharsis/hooks/items/ModelManagerHook
@@ -14,3 +21,4 @@ inject-interface net/minecraft/server/packs/repository/Pack me/owdding/catharsis
 inject-interface net/minecraft/server/packs/repository/Pack$Metadata me/owdding/catharsis/hooks/pack/PackMetadataHook
 inject-interface net/minecraft/world/inventory/Slot me/owdding/catharsis/hooks/gui/SlotHook
 inject-interface net/minecraft/world/item/component/ItemLore me/owdding/catharsis/hooks/text/TooltipProviderHook
+inject-interface net/minecraft/world/entity/Entity me/owdding/catharsis/hooks/entity/EntityHook

--- a/src/main/java/me/owdding/catharsis/hooks/entity/EntityHook.java
+++ b/src/main/java/me/owdding/catharsis/hooks/entity/EntityHook.java
@@ -1,0 +1,14 @@
+package me.owdding.catharsis.hooks.entity;
+
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+
+public interface EntityHook {
+
+    default void catharsis$resetCustomModel() {
+        throw new UnsupportedOperationException();
+    }
+
+    default CustomEntityModel catharsis$getCustomEntityModel() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/me/owdding/catharsis/hooks/entity/EntityRenderStateHook.java
+++ b/src/main/java/me/owdding/catharsis/hooks/entity/EntityRenderStateHook.java
@@ -1,0 +1,15 @@
+package me.owdding.catharsis.hooks.entity;
+
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import org.jetbrains.annotations.Nullable;
+
+public interface EntityRenderStateHook {
+
+    default void catharsis$setCustomEntityModel(@Nullable CustomEntityModel textureLocation) {
+        throw new UnsupportedOperationException();
+    }
+    
+    default @Nullable CustomEntityModel catharsis$getCustomEntityModel() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/me/owdding/catharsis/mixins/entity/EntityMixin.java
+++ b/src/main/java/me/owdding/catharsis/mixins/entity/EntityMixin.java
@@ -1,0 +1,45 @@
+package me.owdding.catharsis.mixins.entity;
+
+import me.owdding.catharsis.features.entity.CustomEntityDefinitions;
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import me.owdding.catharsis.features.entity.models.CustomEntityModels;
+import me.owdding.catharsis.hooks.entity.EntityHook;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(Entity.class)
+public class EntityMixin implements EntityHook {
+
+    @Unique
+    private boolean catharsis$hasComputedModel = false;
+    @Unique
+    private CustomEntityModel catharsis$computedReplacement = null;
+
+    @Override
+    public void catharsis$resetCustomModel() {
+        catharsis$hasComputedModel = false;
+    }
+
+    @Override
+    public CustomEntityModel catharsis$getCustomEntityModel() {
+        if (catharsis$hasComputedModel) {
+            return catharsis$computedReplacement;
+        }
+
+        var customEntity = CustomEntityDefinitions.getFor((Entity) (Object) this);
+
+        catharsis$hasComputedModel = true;
+
+        CustomEntityModel customModel = null;
+
+        if (customEntity != null) {
+            customModel = CustomEntityModels.getModel(customEntity);
+        }
+
+
+        catharsis$computedReplacement = customModel;
+
+        return customModel;
+    }
+}

--- a/src/main/java/me/owdding/catharsis/mixins/entity/EntityRenderStateMixin.java
+++ b/src/main/java/me/owdding/catharsis/mixins/entity/EntityRenderStateMixin.java
@@ -1,0 +1,23 @@
+package me.owdding.catharsis.mixins.entity;
+
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import me.owdding.catharsis.hooks.entity.EntityRenderStateHook;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(EntityRenderState.class)
+public class EntityRenderStateMixin implements EntityRenderStateHook {
+    @Unique
+    private CustomEntityModel catharsis$customTexture = null;
+
+    @Override
+    public void catharsis$setCustomEntityModel(CustomEntityModel textureLocation) {
+        catharsis$customTexture = textureLocation;
+    }
+
+    @Override
+    public CustomEntityModel catharsis$getCustomEntityModel() {
+        return catharsis$customTexture;
+    }
+}

--- a/src/main/java/me/owdding/catharsis/mixins/entity/EntityRendererMixin.java
+++ b/src/main/java/me/owdding/catharsis/mixins/entity/EntityRendererMixin.java
@@ -1,0 +1,23 @@
+package me.owdding.catharsis.mixins.entity;
+
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityRenderer.class)
+public class EntityRendererMixin<T extends Entity, S extends EntityRenderState> {
+
+    @Inject(
+        method = "extractRenderState",
+        at = @At("TAIL")
+    )
+    public void extractRenderState(T entity, S reusedState, float partialTick, CallbackInfo ci) {
+        CustomEntityModel customTexture = entity.catharsis$getCustomEntityModel();
+        reusedState.catharsis$setCustomEntityModel(customTexture);
+    }
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/CustomEntityDefinition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/CustomEntityDefinition.kt
@@ -1,0 +1,19 @@
+package me.owdding.catharsis.features.entity
+
+import me.owdding.catharsis.features.entity.conditions.EntityCondition
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EntityType
+
+
+@GenerateCodec
+data class CustomEntityDefinition(
+    val target: EntityCondition,
+    val type: EntityType<*>
+) {
+    fun matches(entity: Entity): Boolean {
+        if (entity.type != type) return false
+
+        return target.matches(entity)
+    }
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/CustomEntityDefinitions.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/CustomEntityDefinitions.kt
@@ -1,0 +1,66 @@
+package me.owdding.catharsis.features.entity
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
+import me.owdding.catharsis.Catharsis
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.ktmodules.Module
+import net.minecraft.resources.FileToIdConverter
+import net.minecraft.resources.Identifier
+import net.minecraft.server.packs.resources.ResourceManager
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener
+import net.minecraft.util.profiling.ProfilerFiller
+import net.minecraft.world.entity.Entity
+import tech.thatgravyboat.skyblockapi.helpers.McClient
+import tech.thatgravyboat.skyblockapi.utils.json.Json.toDataOrThrow
+
+@Module
+object CustomEntityDefinitions : SimplePreparableReloadListener<Map<Identifier, CustomEntityDefinition>>() {
+
+    private val logger = Catharsis.featureLogger("EntityDefinitions")
+    private val converter = FileToIdConverter.json("catharsis/entity_definitions")
+    private val gson = GsonBuilder().create()
+    private val codec = CatharsisCodecs.getCodec<CustomEntityDefinition>()
+
+    private val definitions = mutableMapOf<Identifier, CustomEntityDefinition>()
+
+    override fun prepare(
+        resourceManager: ResourceManager,
+        profiler: ProfilerFiller,
+    ): Map<Identifier, CustomEntityDefinition> {
+        return converter.listMatchingResources(resourceManager)
+            .mapNotNull { (file, resource) ->
+                logger.runCatching("Error loading entity definition $file") {
+                    resource.openAsReader().use { bufferedReader ->
+                        val id = converter.fileToId(file)
+                        val definition = gson.fromJson(bufferedReader, JsonElement::class.java).toDataOrThrow(codec)
+
+                        id to definition
+                    }
+                }
+            }
+            .associate { it }
+    }
+
+    override fun apply(
+        definitions: Map<Identifier, CustomEntityDefinition>,
+        resourceManager: ResourceManager,
+        profiler: ProfilerFiller,
+    ) {
+        this.definitions.clear()
+        this.definitions.putAll(definitions)
+    }
+
+    @JvmStatic
+    fun getFor(entity: Entity): Identifier? {
+        for ((identifier, definition) in definitions) {
+            if (definition.matches(entity)) return identifier
+        }
+
+        return null
+    }
+
+    init {
+        McClient.registerClientReloadListener(Catharsis.id("entity_definitions"), this)
+    }
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/CustomEntityDefinitions.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/CustomEntityDefinitions.kt
@@ -11,6 +11,7 @@ import net.minecraft.server.packs.resources.ResourceManager
 import net.minecraft.server.packs.resources.SimplePreparableReloadListener
 import net.minecraft.util.profiling.ProfilerFiller
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EntityType
 import tech.thatgravyboat.skyblockapi.helpers.McClient
 import tech.thatgravyboat.skyblockapi.utils.json.Json.toDataOrThrow
 
@@ -22,7 +23,7 @@ object CustomEntityDefinitions : SimplePreparableReloadListener<Map<Identifier, 
     private val gson = GsonBuilder().create()
     private val codec = CatharsisCodecs.getCodec<CustomEntityDefinition>()
 
-    private val definitions = mutableMapOf<Identifier, CustomEntityDefinition>()
+    private val definitions = mutableMapOf<EntityType<*>, MutableMap<Identifier, CustomEntityDefinition>>()
 
     override fun prepare(
         resourceManager: ResourceManager,
@@ -48,16 +49,15 @@ object CustomEntityDefinitions : SimplePreparableReloadListener<Map<Identifier, 
         profiler: ProfilerFiller,
     ) {
         this.definitions.clear()
-        this.definitions.putAll(definitions)
+        for ((id, definition) in definitions.entries) {
+            this.definitions.computeIfAbsent(definition.type) { mutableMapOf() }[id] = definition
+        }
     }
 
     @JvmStatic
     fun getFor(entity: Entity): Identifier? {
-        for ((identifier, definition) in definitions) {
-            if (definition.matches(entity)) return identifier
-        }
-
-        return null
+        val type = entity.type ?: return null
+        return definitions[type]?.entries?.firstOrNull { it.value.matches(entity) }?.key
     }
 
     init {

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AllEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AllEntityCondition.kt
@@ -1,0 +1,16 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.world.entity.Entity
+
+@GenerateCodec
+data class AllEntityCondition(
+    val conditions: List<EntityCondition>
+) : EntityCondition {
+    override fun matches(entity: Entity): Boolean {
+        return conditions.all { it.matches(entity) }
+    }
+
+    override fun codec() = CatharsisCodecs.getMapCodec<AllEntityCondition>()
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AllEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AllEntityCondition.kt
@@ -1,5 +1,6 @@
 package me.owdding.catharsis.features.entity.conditions
 
+import com.mojang.serialization.MapCodec
 import me.owdding.catharsis.generated.CatharsisCodecs
 import me.owdding.ktcodecs.GenerateCodec
 import net.minecraft.world.entity.Entity
@@ -8,9 +9,10 @@ import net.minecraft.world.entity.Entity
 data class AllEntityCondition(
     val conditions: List<EntityCondition>
 ) : EntityCondition {
-    override fun matches(entity: Entity): Boolean {
-        return conditions.all { it.matches(entity) }
-    }
 
-    override fun codec() = CatharsisCodecs.getMapCodec<AllEntityCondition>()
+    override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<AllEntityCondition>()
+    override val cost: Int = this.conditions.sumOf { it.cost } + 1
+
+    override fun matches(entity: Entity): Boolean = conditions.all { it.matches(entity) }
+    override fun optimize(): EntityCondition = AllEntityCondition(this.conditions.map(EntityCondition::optimize).sortedBy(EntityCondition::cost))
 }

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AnyEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AnyEntityCondition.kt
@@ -1,0 +1,16 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.world.entity.Entity
+
+@GenerateCodec
+data class AnyEntityCondition(
+    val conditions: List<EntityCondition>
+) : EntityCondition {
+    override fun matches(entity: Entity): Boolean {
+        return conditions.any { it.matches(entity) }
+    }
+
+    override fun codec() = CatharsisCodecs.getMapCodec<AnyEntityCondition>()
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AnyEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AnyEntityCondition.kt
@@ -1,5 +1,6 @@
 package me.owdding.catharsis.features.entity.conditions
 
+import com.mojang.serialization.MapCodec
 import me.owdding.catharsis.generated.CatharsisCodecs
 import me.owdding.ktcodecs.GenerateCodec
 import net.minecraft.world.entity.Entity
@@ -8,9 +9,10 @@ import net.minecraft.world.entity.Entity
 data class AnyEntityCondition(
     val conditions: List<EntityCondition>
 ) : EntityCondition {
-    override fun matches(entity: Entity): Boolean {
-        return conditions.any { it.matches(entity) }
-    }
 
-    override fun codec() = CatharsisCodecs.getMapCodec<AnyEntityCondition>()
+    override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<AnyEntityCondition>()
+    override val cost: Int = this.conditions.sumOf { it.cost } + 1
+
+    override fun matches(entity: Entity): Boolean = conditions.any { it.matches(entity) }
+    override fun optimize(): EntityCondition = AnyEntityCondition(this.conditions.map(EntityCondition::optimize).sortedBy(EntityCondition::cost))
 }

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AttributeEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AttributeEntityCondition.kt
@@ -1,0 +1,30 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.catharsis.utils.types.FloatPredicate
+import me.owdding.ktcodecs.Compact
+import me.owdding.ktcodecs.FieldNames
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.core.Holder
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.ai.attributes.Attribute
+import tech.thatgravyboat.skyblockapi.utils.extentions.serverValue
+
+@GenerateCodec
+data class AttributeEntityCondition(
+    val attribute: Holder<Attribute>,
+    @FieldNames("values", "value") @Compact val values: FloatPredicate,
+) : EntityCondition {
+    override fun matches(entity: Entity): Boolean {
+        if (entity !is LivingEntity) return false
+
+        val attributeInstance = entity.getAttribute(attribute) ?: return false
+
+        val attributeValue = attributeInstance.serverValue
+
+        return values.contains(attributeValue)
+    }
+
+    override fun codec() = CatharsisCodecs.getMapCodec<AttributeEntityCondition>()
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AttributeEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/AttributeEntityCondition.kt
@@ -1,5 +1,6 @@
 package me.owdding.catharsis.features.entity.conditions
 
+import com.mojang.serialization.MapCodec
 import me.owdding.catharsis.generated.CatharsisCodecs
 import me.owdding.catharsis.utils.types.FloatPredicate
 import me.owdding.ktcodecs.Compact
@@ -16,6 +17,9 @@ data class AttributeEntityCondition(
     val attribute: Holder<Attribute>,
     @FieldNames("values", "value") @Compact val values: FloatPredicate,
 ) : EntityCondition {
+
+    override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<AttributeEntityCondition>()
+
     override fun matches(entity: Entity): Boolean {
         if (entity !is LivingEntity) return false
 
@@ -25,6 +29,4 @@ data class AttributeEntityCondition(
 
         return values.contains(attributeValue)
     }
-
-    override fun codec() = CatharsisCodecs.getMapCodec<AttributeEntityCondition>()
 }

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EntityCondition.kt
@@ -28,5 +28,7 @@ object EntityConditions {
         ID_MAPPER.put(Catharsis.id("attribute"), CatharsisCodecs.getMapCodec<AttributeEntityCondition>())
         ID_MAPPER.put(Catharsis.id("island"), CatharsisCodecs.getMapCodec<IslandEntityCondition>())
         ID_MAPPER.put(Catharsis.id("equipment"), CatharsisCodecs.getMapCodec<EquipmentEntityCondition>())
+        ID_MAPPER.put(Catharsis.id("any"), CatharsisCodecs.getMapCodec<AnyEntityCondition>())
+        ID_MAPPER.put(Catharsis.id("all"), CatharsisCodecs.getMapCodec<AllEntityCondition>())
     }
 }

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EntityCondition.kt
@@ -10,16 +10,21 @@ import net.minecraft.util.ExtraCodecs
 import net.minecraft.world.entity.Entity
 
 interface EntityCondition {
-    fun matches(entity: Entity): Boolean
 
-    fun codec(): MapCodec<out EntityCondition>
+    val codec: MapCodec<out EntityCondition>
+    val cost: Int get() = 0
+
+    fun matches(entity: Entity): Boolean
+    fun optimize(): EntityCondition = this
 }
 
 object EntityConditions {
     val ID_MAPPER = ExtraCodecs.LateBoundIdMapper<Identifier, MapCodec<out EntityCondition>>()
 
     @IncludedCodec
-    val CODEC: MapCodec<EntityCondition> = ID_MAPPER.codec(IncludedCodecs.catharsisIdentifier).dispatchMap(EntityCondition::codec) { it }
+    val CODEC: MapCodec<EntityCondition> = ID_MAPPER.codec(IncludedCodecs.catharsisIdentifier)
+        .dispatchMap(EntityCondition::codec) { it }
+        .xmap(EntityCondition::optimize) { it }
 
     init {
         ID_MAPPER.put(Catharsis.id("npc_skin"), CatharsisCodecs.getMapCodec<PlayerEntityConditions.NpcSkin>())

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EntityCondition.kt
@@ -1,0 +1,32 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import com.mojang.serialization.MapCodec
+import me.owdding.catharsis.Catharsis
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.catharsis.utils.codecs.IncludedCodecs
+import me.owdding.ktcodecs.IncludedCodec
+import net.minecraft.resources.Identifier
+import net.minecraft.util.ExtraCodecs
+import net.minecraft.world.entity.Entity
+
+interface EntityCondition {
+    fun matches(entity: Entity): Boolean
+
+    fun codec(): MapCodec<out EntityCondition>
+}
+
+object EntityConditions {
+    val ID_MAPPER = ExtraCodecs.LateBoundIdMapper<Identifier, MapCodec<out EntityCondition>>()
+
+    @IncludedCodec
+    val CODEC: MapCodec<EntityCondition> = ID_MAPPER.codec(IncludedCodecs.catharsisIdentifier).dispatchMap(EntityCondition::codec) { it }
+
+    init {
+        ID_MAPPER.put(Catharsis.id("npc_skin"), CatharsisCodecs.getMapCodec<PlayerEntityConditions.NpcSkin>())
+        ID_MAPPER.put(Catharsis.id("player_skin"), CatharsisCodecs.getMapCodec<PlayerEntityConditions.PlayerSkin>())
+        ID_MAPPER.put(Catharsis.id("identity"), CatharsisCodecs.getMapCodec<IdentityEntityCondition>())
+        ID_MAPPER.put(Catharsis.id("attribute"), CatharsisCodecs.getMapCodec<AttributeEntityCondition>())
+        ID_MAPPER.put(Catharsis.id("island"), CatharsisCodecs.getMapCodec<IslandEntityCondition>())
+        ID_MAPPER.put(Catharsis.id("equipment"), CatharsisCodecs.getMapCodec<EquipmentEntityCondition>())
+    }
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EquipmentEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EquipmentEntityCondition.kt
@@ -1,5 +1,6 @@
 package me.owdding.catharsis.features.entity.conditions
 
+import com.mojang.serialization.MapCodec
 import me.owdding.catharsis.generated.CatharsisCodecs
 import me.owdding.ktcodecs.GenerateCodec
 import net.minecraft.client.multiplayer.ClientLevel
@@ -14,6 +15,10 @@ data class EquipmentEntityCondition(
     val slot: EquipmentSlot,
     val property: ConditionalItemModelProperty,
 ) : EntityCondition {
+
+    override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<EquipmentEntityCondition>()
+    override val cost: Int = 10
+
     override fun matches(entity: Entity): Boolean {
         if (entity !is LivingEntity) return false
 
@@ -27,6 +32,4 @@ data class EquipmentEntityCondition(
             ItemDisplayContext.NONE,
         )
     }
-
-    override fun codec() = CatharsisCodecs.getMapCodec<EquipmentEntityCondition>()
 }

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EquipmentEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/EquipmentEntityCondition.kt
@@ -1,0 +1,32 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.client.multiplayer.ClientLevel
+import net.minecraft.client.renderer.item.properties.conditional.ConditionalItemModelProperty
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.item.ItemDisplayContext
+
+@GenerateCodec
+data class EquipmentEntityCondition(
+    val slot: EquipmentSlot,
+    val property: ConditionalItemModelProperty,
+) : EntityCondition {
+    override fun matches(entity: Entity): Boolean {
+        if (entity !is LivingEntity) return false
+
+        val equipmentInSlot = entity.getItemBySlot(slot)
+
+        return property.get(
+            equipmentInSlot,
+            entity.level() as? ClientLevel,
+            entity,
+            entity.id,
+            ItemDisplayContext.NONE,
+        )
+    }
+
+    override fun codec() = CatharsisCodecs.getMapCodec<EquipmentEntityCondition>()
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IdentityEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IdentityEntityCondition.kt
@@ -1,5 +1,6 @@
 package me.owdding.catharsis.features.entity.conditions
 
+import com.mojang.serialization.MapCodec
 import me.owdding.catharsis.generated.CatharsisCodecs
 import me.owdding.ktcodecs.GenerateCodec
 import net.minecraft.world.entity.Entity
@@ -12,12 +13,13 @@ data class IdentityEntityCondition(
     val name: String?
 ) : EntityCondition {
 
+    override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<IdentityEntityCondition>()
+    override val cost: Int = if (name != null) 2 else super.cost
+
     override fun matches(entity: Entity): Boolean {
         if (uuid != null && entity.uuid != uuid) return false
         if (name != null && entity.cleanName != name) return false
 
         return true
     }
-
-    override fun codec() = CatharsisCodecs.getMapCodec<IdentityEntityCondition>()
 }

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IdentityEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IdentityEntityCondition.kt
@@ -1,0 +1,23 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.world.entity.Entity
+import tech.thatgravyboat.skyblockapi.utils.extentions.cleanName
+import java.util.*
+
+@GenerateCodec
+data class IdentityEntityCondition(
+    val uuid: UUID?,
+    val name: String?
+) : EntityCondition {
+
+    override fun matches(entity: Entity): Boolean {
+        if (uuid != null && entity.uuid != uuid) return false
+        if (name != null && entity.cleanName != name) return false
+
+        return true
+    }
+
+    override fun codec() = CatharsisCodecs.getMapCodec<IdentityEntityCondition>()
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IslandEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IslandEntityCondition.kt
@@ -1,5 +1,6 @@
 package me.owdding.catharsis.features.entity.conditions
 
+import com.mojang.serialization.MapCodec
 import me.owdding.catharsis.generated.CatharsisCodecs
 import me.owdding.ktcodecs.Compact
 import me.owdding.ktcodecs.FieldNames
@@ -12,7 +13,7 @@ data class IslandEntityCondition(
     @FieldNames("islands", "island") @Compact val islands: List<SkyBlockIsland>,
 ) : EntityCondition {
 
-    override fun matches(entity: Entity) = SkyBlockIsland.inAnyIsland(islands)
+    override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<IslandEntityCondition>()
 
-    override fun codec() = CatharsisCodecs.getMapCodec<IslandEntityCondition>()
+    override fun matches(entity: Entity) = SkyBlockIsland.inAnyIsland(islands)
 }

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IslandEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/IslandEntityCondition.kt
@@ -1,0 +1,18 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.ktcodecs.Compact
+import me.owdding.ktcodecs.FieldNames
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.world.entity.Entity
+import tech.thatgravyboat.skyblockapi.api.location.SkyBlockIsland
+
+@GenerateCodec
+data class IslandEntityCondition(
+    @FieldNames("islands", "island") @Compact val islands: List<SkyBlockIsland>,
+) : EntityCondition {
+
+    override fun matches(entity: Entity) = SkyBlockIsland.inAnyIsland(islands)
+
+    override fun codec() = CatharsisCodecs.getMapCodec<IslandEntityCondition>()
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/PlayerEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/PlayerEntityCondition.kt
@@ -1,0 +1,57 @@
+package me.owdding.catharsis.features.entity.conditions
+
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.ktcodecs.Compact
+import me.owdding.ktcodecs.FieldNames
+import me.owdding.ktcodecs.GenerateCodec
+import net.minecraft.client.entity.ClientAvatarEntity
+import net.minecraft.core.ClientAsset
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.player.Player
+import tech.thatgravyboat.skyblockapi.utils.extentions.isRealPlayer
+
+
+sealed interface PlayerEntityConditions : EntityCondition {
+    @GenerateCodec
+    data class NpcSkin(
+        @FieldNames("skins", "skin") @Compact val skins: Set<String>
+    ) : PlayerEntityConditions {
+        override fun matches(entity: Entity): Boolean {
+            if (entity !is ClientAvatarEntity) return false
+            if (entity is Player && entity.isRealPlayer()) return false
+
+            val skin = getSkin(entity) ?: return false
+
+            return skin in skins
+        }
+
+        override fun codec() = CatharsisCodecs.getMapCodec<NpcSkin>()
+    }
+
+    @GenerateCodec
+    data class PlayerSkin(
+        @FieldNames("skins", "skin") @Compact val skins: Set<String>
+    ) : PlayerEntityConditions {
+        override fun matches(entity: Entity): Boolean {
+            if (entity !is ClientAvatarEntity) return false
+            if (entity !is Player || !entity.isRealPlayer()) return false
+
+            val skin = getSkin(entity) ?: return false
+
+            return skin in skins
+        }
+
+        override fun codec() = CatharsisCodecs.getMapCodec<PlayerSkin>()
+    }
+
+    fun getSkin(entity: ClientAvatarEntity): String? {
+        //? if > 1.21.8 {
+        val bodySkin = entity.skin.body
+        if (bodySkin !is ClientAsset.DownloadedTexture) return null
+        val skinUrl = bodySkin.url
+        //?} else {
+        /*val skinUrl = entity.skin.textureUrl
+        *///?}
+        return skinUrl
+    }
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/PlayerEntityCondition.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/conditions/PlayerEntityCondition.kt
@@ -1,5 +1,6 @@
 package me.owdding.catharsis.features.entity.conditions
 
+import com.mojang.serialization.MapCodec
 import me.owdding.catharsis.generated.CatharsisCodecs
 import me.owdding.ktcodecs.Compact
 import me.owdding.ktcodecs.FieldNames
@@ -16,6 +17,9 @@ sealed interface PlayerEntityConditions : EntityCondition {
     data class NpcSkin(
         @FieldNames("skins", "skin") @Compact val skins: Set<String>
     ) : PlayerEntityConditions {
+
+        override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<NpcSkin>()
+
         override fun matches(entity: Entity): Boolean {
             if (entity !is ClientAvatarEntity) return false
             if (entity is Player && entity.isRealPlayer()) return false
@@ -24,14 +28,15 @@ sealed interface PlayerEntityConditions : EntityCondition {
 
             return skin in skins
         }
-
-        override fun codec() = CatharsisCodecs.getMapCodec<NpcSkin>()
     }
 
     @GenerateCodec
     data class PlayerSkin(
         @FieldNames("skins", "skin") @Compact val skins: Set<String>
     ) : PlayerEntityConditions {
+
+        override val codec: MapCodec<out EntityCondition> = CatharsisCodecs.getMapCodec<PlayerSkin>()
+
         override fun matches(entity: Entity): Boolean {
             if (entity !is ClientAvatarEntity) return false
             if (entity !is Player || !entity.isRealPlayer()) return false
@@ -40,8 +45,6 @@ sealed interface PlayerEntityConditions : EntityCondition {
 
             return skin in skins
         }
-
-        override fun codec() = CatharsisCodecs.getMapCodec<PlayerSkin>()
     }
 
     fun getSkin(entity: ClientAvatarEntity): String? {

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/models/CustomEntityModel.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/models/CustomEntityModel.kt
@@ -1,0 +1,79 @@
+package me.owdding.catharsis.features.entity.models
+
+import me.owdding.catharsis.Catharsis
+import me.owdding.catharsis.utils.geometry.SafeModelPart
+import me.owdding.catharsis.utils.TypedResourceManager
+import me.owdding.catharsis.utils.extensions.unsafeCast
+import me.owdding.catharsis.utils.geometry.BedrockGeometry
+import me.owdding.ktcodecs.FieldName
+import me.owdding.ktcodecs.GenerateCodec
+import me.owdding.ktcodecs.NamedCodec
+import net.minecraft.client.model.EntityModel
+import net.minecraft.client.model.geom.ModelPart
+import net.minecraft.client.model.player.PlayerModel
+import net.minecraft.client.renderer.entity.state.EntityRenderState
+import net.minecraft.resources.Identifier
+
+data class CustomEntityModel(
+    val texture: Identifier,
+    val emissiveTexture: Identifier?,
+    val model: ModelPart?
+) {
+
+    private var cachedEntityModel: EntityModel<out EntityRenderState>? = null
+
+    fun <T : EntityRenderState> replaceModel(oldModel: EntityModel<T>): EntityModel<T> {
+        val newCustomEntityModelPart = model ?: return oldModel
+
+        val cachedEntityModel = cachedEntityModel
+        if (cachedEntityModel != null) {
+            return cachedEntityModel.unsafeCast()
+        }
+
+        if (oldModel is PlayerModel) {
+            val newPlayerModel = PlayerModel(newCustomEntityModelPart, oldModel.slim)
+
+            this.cachedEntityModel = newPlayerModel
+            return newPlayerModel.unsafeCast()
+        }
+
+        try {
+            val modelConstructor = oldModel.javaClass.getConstructor(ModelPart::class.java)
+
+            val newModel = modelConstructor.newInstance(newCustomEntityModelPart)
+
+            this.cachedEntityModel = newModel
+
+            return newModel
+        } catch (_: NoSuchMethodException) {
+            Catharsis.error("Failed to replace a model: Failed to construct ${oldModel.javaClass.name}")
+
+            // If the constructor doesn't exist on one call it is unlikely to exist in the future
+            this.cachedEntityModel = oldModel
+
+            return oldModel
+        }
+    }
+
+    @GenerateCodec
+    @NamedCodec("UnbakedCustomEntityModel")
+    data class Unbaked(
+        val texture: Identifier,
+        @FieldName("emissive_texture") val emissiveTexture: Identifier?,
+        val model: Identifier?
+    ) {
+        fun bake(resources: TypedResourceManager): CustomEntityModel {
+            val bakedModel = if (model != null) {
+                val bedrockModel = resources.getOrLoad(model, BedrockGeometry.RESOURCE_PARSER)!!.getOrThrow()
+
+                SafeModelPart.convertFromBedrockModel(bedrockModel)
+            } else null
+
+            return CustomEntityModel(
+                texture,
+                emissiveTexture,
+                bakedModel
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/models/CustomEntityModel.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/models/CustomEntityModel.kt
@@ -37,22 +37,18 @@ data class CustomEntityModel(
             return newPlayerModel.unsafeCast()
         }
 
-        try {
-            val modelConstructor = oldModel.javaClass.getConstructor(ModelPart::class.java)
-
-            val newModel = modelConstructor.newInstance(newCustomEntityModelPart)
-
-            this.cachedEntityModel = newModel
-
-            return newModel
-        } catch (_: NoSuchMethodException) {
-            Catharsis.error("Failed to replace a model: Failed to construct ${oldModel.javaClass.name}")
+        val newModel = runCatching {
+            oldModel.javaClass.getConstructor(ModelPart::class.java).newInstance(newCustomEntityModelPart)
+        }.getOrElse {
+            Catharsis.error("Failed to replace a model: Failed to construct ${oldModel.javaClass.name}", it)
 
             // If the constructor doesn't exist on one call it is unlikely to exist in the future
-            this.cachedEntityModel = oldModel
-
-            return oldModel
+            oldModel
         }
+
+        this.cachedEntityModel = newModel
+
+        return newModel
     }
 
     @GenerateCodec

--- a/src/main/kotlin/me/owdding/catharsis/features/entity/models/CustomEntityModels.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/entity/models/CustomEntityModels.kt
@@ -1,0 +1,85 @@
+package me.owdding.catharsis.features.entity.models
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
+import me.owdding.catharsis.Catharsis
+import me.owdding.catharsis.generated.CatharsisCodecs
+import me.owdding.catharsis.utils.TypedResourceManager
+import me.owdding.ktmodules.Module
+import net.minecraft.resources.FileToIdConverter
+import net.minecraft.resources.Identifier
+import net.minecraft.server.packs.resources.ResourceManager
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener
+import net.minecraft.util.profiling.ProfilerFiller
+import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
+import tech.thatgravyboat.skyblockapi.api.events.entity.EntityAttributesUpdateEvent
+import tech.thatgravyboat.skyblockapi.api.events.entity.EntityEquipmentUpdateEvent
+import tech.thatgravyboat.skyblockapi.helpers.McClient
+import tech.thatgravyboat.skyblockapi.helpers.McLevel
+import tech.thatgravyboat.skyblockapi.utils.json.Json.toDataOrThrow
+
+@Module
+object CustomEntityModels : SimplePreparableReloadListener<Map<Identifier, CustomEntityModel>>() {
+
+    private val logger = Catharsis.featureLogger("EntityModels")
+    private val converter = FileToIdConverter.json("catharsis/entities")
+    private val gson = GsonBuilder().create()
+    private val codec = CatharsisCodecs.getCodec<CustomEntityModel.Unbaked>()
+
+    private val definitions = mutableMapOf<Identifier, CustomEntityModel>()
+
+    override fun prepare(
+        resourceManager: ResourceManager,
+        profiler: ProfilerFiller,
+    ): Map<Identifier, CustomEntityModel> {
+        val resources = TypedResourceManager(resourceManager)
+
+        return converter.listMatchingResources(resourceManager)
+            .mapNotNull { (fileName, resource) ->
+                logger.runCatching("Error loading entity model $fileName") {
+                    resource.openAsReader().use { bufferedReader ->
+                        val definition = gson.fromJson(bufferedReader, JsonElement::class.java).toDataOrThrow(codec).bake(resources)
+
+                        val id = converter.fileToId(fileName)
+
+                        id to definition
+                    }
+                }
+            }
+            .associate { it }
+    }
+
+    override fun apply(
+        definitions: Map<Identifier, CustomEntityModel>,
+        resourceManager: ResourceManager,
+        profiler: ProfilerFiller,
+    ) {
+        this.definitions.clear()
+        this.definitions.putAll(definitions)
+
+        if (McLevel.hasLevel) {
+            for (entity in McLevel.level.entitiesForRendering()) {
+                entity.`catharsis$resetCustomModel`()
+            }
+        }
+    }
+
+    @Subscription
+    private fun EntityAttributesUpdateEvent.onAttributeUpdate() {
+        this.entity.`catharsis$resetCustomModel`()
+    }
+
+    @Subscription
+    private fun EntityEquipmentUpdateEvent.onEquipmentUpdate() {
+        this.entity.`catharsis$resetCustomModel`()
+    }
+
+    @JvmStatic
+    fun getModel(identifier: Identifier): CustomEntityModel? {
+        return definitions[identifier]
+    }
+
+    init {
+        McClient.registerClientReloadListener(Catharsis.id("entity_replacements"), this)
+    }
+}

--- a/src/main/kotlin/me/owdding/catharsis/utils/codecs/IncludedCodecs.kt
+++ b/src/main/kotlin/me/owdding/catharsis/utils/codecs/IncludedCodecs.kt
@@ -12,6 +12,7 @@ import me.owdding.ktcodecs.IncludedCodec
 import net.minecraft.client.color.item.ItemTintSource
 import net.minecraft.client.color.item.ItemTintSources
 import net.minecraft.client.renderer.block.model.BlockModelDefinition
+import net.minecraft.core.Holder
 import net.minecraft.core.component.DataComponentType
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.core.registries.Registries
@@ -21,6 +22,8 @@ import net.minecraft.resources.Identifier
 import net.minecraft.sounds.SoundEvent
 import net.minecraft.tags.TagKey
 import net.minecraft.util.ExtraCodecs
+import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.ai.attributes.Attribute
 import net.minecraft.world.inventory.MenuType
 import net.minecraft.world.item.Item
 import net.minecraft.world.level.block.Block
@@ -127,5 +130,11 @@ object IncludedCodecs {
     val instant: Codec<Instant> = Codec.LONG.xmap(Instant::fromEpochMilliseconds, Instant::toEpochMilliseconds)
 
     @IncludedCodec(keyable = true)
+    val attribute: Codec<Holder<Attribute>> = BuiltInRegistries.ATTRIBUTE.holderByNameCodec()
+
+    @IncludedCodec
+    val entityType: Codec<EntityType<*>> = BuiltInRegistries.ENTITY_TYPE.byNameCodec()
+    
+    @IncludedCodec
     val dataComponentCodec: Codec<DataComponentType<*>> = BuiltInRegistries.DATA_COMPONENT_TYPE.byNameCodec()
 }

--- a/src/main/kotlin/me/owdding/catharsis/utils/extensions/JomlExtensions.kt
+++ b/src/main/kotlin/me/owdding/catharsis/utils/extensions/JomlExtensions.kt
@@ -46,3 +46,5 @@ fun Vector3i.toVec3i(): Vec3i = Vec3i(x, y, z)
 
 fun BlockPos.add(vec3: Vector3ic): BlockPos = this.offset(vec3.x(), vec3.y(), vec3.z())
 operator fun BlockPos.plus(vec3: Vector3ic): BlockPos = add(vec3)
+
+fun List<Float>.toVector3f(): Vector3f = if (this.size == 3) Vector3f(this[0], this[1], this[2]) else throw IllegalArgumentException("Vector size is too large")

--- a/src/main/kotlin/me/owdding/catharsis/utils/geometry/SafeModelPart.kt
+++ b/src/main/kotlin/me/owdding/catharsis/utils/geometry/SafeModelPart.kt
@@ -1,0 +1,190 @@
+package me.owdding.catharsis.utils.geometry
+
+import me.owdding.catharsis.Catharsis
+import me.owdding.catharsis.utils.extensions.toVector3f
+import net.minecraft.client.model.geom.ModelPart
+import net.minecraft.client.model.geom.PartPose
+import net.minecraft.client.model.geom.builders.CubeDeformation
+import net.minecraft.client.model.geom.builders.CubeListBuilder
+import net.minecraft.client.model.geom.builders.MeshDefinition
+import net.minecraft.client.model.geom.builders.PartDefinition
+import org.joml.Vector3f
+import org.joml.plus
+import java.util.function.Function
+import kotlin.jvm.optionals.getOrNull
+
+class SafeModelPart(
+    cubes: List<Cube>,
+    children: Map<String, ModelPart>,
+    initialPose: PartPose,
+    val name: String = "Unnamed",
+    val path: String = "root",
+) : ModelPart(cubes, children) {
+
+    init {
+        this.initialPose = initialPose
+        this.loadPose(initialPose)
+    }
+
+    override fun getChild(name: String): ModelPart {
+        return if (super.hasChild(name)) {
+            val unsafeModelPart = super.getChild(name)
+
+            SafeModelPart(
+                unsafeModelPart.cubes,
+                unsafeModelPart.children,
+                unsafeModelPart.initialPose,
+                this.name,
+                "$path/$name",
+            )
+        } else {
+            Catharsis.warn("model ${this.name} missing bone $name!")
+            DummyModelPart()
+        }
+    }
+
+    override fun createPartLookup(): Function<String, ModelPart?> {
+        val parentLookup = super.createPartLookup()
+        return Function { boneName: String ->
+            val parentBone = parentLookup.apply(boneName)
+            if (parentBone == null) {
+                Catharsis.warn("Bone $boneName in model $name is missing!")
+                DummyModelPart()
+            } else parentBone
+        }
+    }
+
+    companion object {
+        private fun CubeListBuilder.addBedrockCube(pivot: Vector3f, from: Vector3f, size: Vector3f, uv: List<Float>, inflate: Float?, mirror: Boolean?) {
+            val to = from + size
+
+            val cubeOrigin = Vector3f(
+                -(pivot.x - to.x),
+                -from.y - size.y + pivot.y,
+                from.z - pivot.z,
+            )
+
+            texOffs(uv[0].toInt(), uv[1].toInt())
+            if (mirror == true) mirror()
+            addBox(
+                cubeOrigin.x, cubeOrigin.y, cubeOrigin.z,
+                size.x, size.y, size.z,
+                CubeDeformation(inflate ?: 0f),
+            )
+            if (mirror == true) mirror(false)
+        }
+
+        fun convertFromBedrockModel(model: BedrockGeometry?): ModelPart? {
+            if (model == null) return null
+
+            val meshDefinition = MeshDefinition()
+            val root = meshDefinition.root
+            val knownBones = mutableMapOf<String?, PartDefinition>()
+            val knownOffsets = mutableMapOf<String?, Vector3f>()
+
+            knownBones[null] = root
+            knownOffsets[null] = Vector3f(0f, 24f, 0f)
+
+            for (bone in model.bones) {
+                val cubesBuilder = CubeListBuilder.create()
+
+                val parentBone = knownBones[bone.parent] ?: continue
+                val offsetOffset = knownOffsets[bone.parent] ?: continue
+                val pivot = bone.pivot.toVector3f()
+                val offset = Vector3f(
+                    (pivot.x - offsetOffset.x),
+                    -(pivot.y - offsetOffset.y),
+                    pivot.z - offsetOffset.z,
+                )
+
+                val rotatedCubes = mutableListOf<BedrockCube>()
+
+                for (cube in bone.cubes) {
+                    if (cube.uv?.right()?.isPresent ?: true) continue
+                    val uv = cube.uv.left().getOrNull() ?: continue
+                    if (cube.rotation.any { it != 0f }) {
+                        rotatedCubes.add(cube)
+                        continue
+                    }
+
+                    val size = cube.size.toVector3f()
+                    val origin = cube.origin.toVector3f()
+                    val from = Vector3f(
+                        origin.x - size.x,
+                        origin.y,
+                        origin.z
+                    )
+
+                    cubesBuilder.addBedrockCube(pivot, from, size, uv, cube.inflate, cube.mirror)
+                }
+
+                knownOffsets[bone.name] = pivot
+
+                val child = parentBone.addOrReplaceChild(
+                    bone.name,
+                    cubesBuilder,
+                    PartPose.offsetAndRotation(
+                        offset.x, offset.y, offset.z,
+                        Math.toRadians(bone.rotation[0].toDouble()).toFloat(),
+                        Math.toRadians(bone.rotation[1].toDouble()).toFloat(),
+                        Math.toRadians(bone.rotation[2].toDouble()).toFloat()
+                    )
+                )
+
+                for (cube in rotatedCubes) {
+                    val subCubeBuilder = CubeListBuilder.create()
+
+                    val uv = cube.uv?.left()?.getOrNull() ?: continue
+                    val size = cube.size.toVector3f()
+                    val origin = cube.origin.toVector3f()
+                    val from = Vector3f(
+                        origin.x - size.x,
+                        origin.y,
+                        origin.z
+                    )
+                    val cubePivot = cube.pivot.toVector3f()
+
+                    subCubeBuilder.addBedrockCube(cubePivot, from, size, uv, cube.inflate, cube.mirror)
+
+                    val cubePivotOffset = Vector3f(
+                        pivot.x - cubePivot.x,
+                        pivot.y - cubePivot.y,
+                        cubePivot.z - pivot.z,
+                    )
+
+                    child.addOrReplaceChild("rotate_bone", subCubeBuilder, PartPose.offsetAndRotation(
+                        cubePivotOffset.x, cubePivotOffset.y, cubePivotOffset.z,
+                        Math.toRadians(cube.rotation[0].toDouble()).toFloat(),
+                        Math.toRadians(cube.rotation[1].toDouble()).toFloat(),
+                        Math.toRadians(cube.rotation[2].toDouble()).toFloat()
+                    ))
+                }
+
+                knownBones[bone.name] = child
+            }
+
+            val unsafeModelPart = root.bake(model.description.textureWidth, model.description.textureHeight)
+
+            return SafeModelPart(
+                unsafeModelPart.cubes,
+                unsafeModelPart.children,
+                unsafeModelPart.initialPose,
+                name = model.description.identifier,
+            )
+        }
+    }
+}
+
+class DummyModelPart : ModelPart(mutableListOf(), mutableMapOf()) {
+    override fun getChild(name: String): ModelPart {
+        return children.getOrPut(name) {
+            DummyModelPart()
+        }
+    }
+
+    override fun createPartLookup(): Function<String, ModelPart?> {
+        return Function {
+            DummyModelPart()
+        }
+    }
+}

--- a/src/main/resources/catharsis.mixins.json
+++ b/src/main/resources/catharsis.mixins.json
@@ -10,6 +10,10 @@
         "armor.HumanoidModelMixin",
         "armor.LivingEntityRenderStateMixin",
         "armor.SelectItemModelPropertyTypeMixin",
+        "entity.EnderDragonRendererMixin",
+        "entity.EntityRendererMixin",
+        "entity.EntityRenderStateMixin",
+        "entity.LivingEntityRendererMixin",
         "gui.AbstractContainerScreenElementsMixin",
         "gui.AbstractContainerScreenSlotsMixin",
         "gui.SlotMixin",
@@ -42,6 +46,7 @@
         "minVersion": "0.5.0"
     },
     "mixins": [
+        "entity.EntityMixin",
         "gui.AbstractContainerMenuMixin",
         "pack.PathPackResourcesMixin",
         "sounds.BlockItemMixin",

--- a/versions/1.21.10/src/main/java/me/owdding/catharsis/mixins/entity/EnderDragonRendererMixin.java
+++ b/versions/1.21.10/src/main/java/me/owdding/catharsis/mixins/entity/EnderDragonRendererMixin.java
@@ -1,0 +1,53 @@
+package me.owdding.catharsis.mixins.entity;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import net.minecraft.client.renderer.entity.EnderDragonRenderer;
+import net.minecraft.client.renderer.entity.state.EnderDragonRenderState;
+import net.minecraft.client.renderer.RenderType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(EnderDragonRenderer.class)
+public class EnderDragonRendererMixin {
+
+    @ModifyArgs(
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/OrderedSubmitNodeCollector;submitModel(Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/RenderType;IIILnet/minecraft/client/renderer/texture/TextureAtlasSprite;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V",
+            ordinal = 2
+        ),
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/EnderDragonRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V"
+    )
+    public void catharsis$handleDragonTextureReplacement(Args args, @Local(argsOnly = true) EnderDragonRenderState state) {
+        CustomEntityModel customEntityModel = state.catharsis$getCustomEntityModel();
+
+        if (customEntityModel == null) return;
+
+        args.set(
+            3,
+            RenderType.entityCutoutNoCull(customEntityModel.getTexture())
+        );
+    }
+
+    @ModifyArgs(
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/OrderedSubmitNodeCollector;submitModel(Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/RenderType;IIILnet/minecraft/client/renderer/texture/TextureAtlasSprite;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V",
+            ordinal = 1
+        ),
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/EnderDragonRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V"
+    )
+    public void catharsis$handleDragonTextureReplacementDecal(Args args, @Local(argsOnly = true) EnderDragonRenderState state) {
+        CustomEntityModel customEntityModel = state.catharsis$getCustomEntityModel();
+
+        if (customEntityModel == null) return;
+
+        args.set(
+            3,
+            RenderType.entityDecal(customEntityModel.getTexture())
+        );
+    }
+}

--- a/versions/1.21.10/src/main/java/me/owdding/catharsis/mixins/entity/LivingEntityRendererMixin.java
+++ b/versions/1.21.10/src/main/java/me/owdding/catharsis/mixins/entity/LivingEntityRendererMixin.java
@@ -1,0 +1,102 @@
+//~ named_identifier
+package me.owdding.catharsis.mixins.entity;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.vertex.PoseStack;
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.client.renderer.entity.state.ArmorStandRenderState;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.state.CameraRenderState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(LivingEntityRenderer.class)
+public abstract class LivingEntityRendererMixin<S extends LivingEntityRenderState, M extends EntityModel<? super S>> {
+
+    @Shadow
+    protected abstract boolean isBodyVisible(S renderState);
+
+    @Shadow
+    protected M model;
+
+    @WrapMethod(
+       method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V"
+    )
+    private void catharsis$swapOutModel(S renderState, PoseStack poseStack, SubmitNodeCollector nodeCollector, CameraRenderState cameraRenderState, Operation<Void> original) {
+        M originalModel = this.model;
+
+        var customModel = renderState.catharsis$getCustomEntityModel();
+
+        if (customModel != null && customModel.getModel() != null && model instanceof EntityModel<? super S> entityModel) {
+            //noinspection unchecked
+            this.model = (M) customModel.replaceModel(entityModel);
+        }
+
+        original.call(renderState, poseStack, nodeCollector, cameraRenderState);
+
+        this.model = originalModel;
+    }
+    @ModifyArg(
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/SubmitNodeCollector;submitModel(Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/RenderType;IIILnet/minecraft/client/renderer/texture/TextureAtlasSprite;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V"),
+        index = 3
+    )
+    private RenderType catharsis$modifyEntityTexture(RenderType renderType, @Local(argsOnly = true) S renderState) {
+        var customModel = renderState.catharsis$getCustomEntityModel();
+
+        if (customModel != null) {
+            return catharsis$createEntityTextureRenderType(renderState, customModel);
+        }
+
+        return renderType;
+    }
+
+    @WrapWithCondition(
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/layers/RenderLayer;submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/EntityRenderState;FF)V")
+    )
+    private boolean catharsis$modifyEntityLayers(RenderLayer<S, M> instance, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int light, EntityRenderState entityRenderState, float yRot, float xRot) {
+        var customModel = entityRenderState.catharsis$getCustomEntityModel();
+
+        return customModel == null;
+    }
+
+    @Unique
+    private RenderType catharsis$createEntityTextureRenderType(S renderState, CustomEntityModel customEntityModel) {
+        boolean bodyVisible = isBodyVisible(renderState);
+        boolean spectatorVisible = !bodyVisible && !renderState.isInvisibleToPlayer;
+        boolean isArmorStandMarker = renderState instanceof ArmorStandRenderState armorStandRenderState && armorStandRenderState.isMarker;
+        var texture = customEntityModel.getTexture();
+
+        if (isArmorStandMarker) {
+            if (spectatorVisible) {
+                return RenderType.entityTranslucent(texture, false);
+            }
+            if (bodyVisible) {
+                return RenderType.entityCutoutNoCull(texture, false);
+            }
+        }
+
+        if (spectatorVisible) {
+            return RenderType.itemEntityTranslucentCull(texture);
+        }
+
+        if (bodyVisible) {
+            return model.renderType(texture);
+        }
+
+        return RenderType.outline(texture);
+    }
+}

--- a/versions/1.21.11/src/main/java/me/owdding/catharsis/mixins/entity/EnderDragonRendererMixin.java
+++ b/versions/1.21.11/src/main/java/me/owdding/catharsis/mixins/entity/EnderDragonRendererMixin.java
@@ -1,0 +1,53 @@
+package me.owdding.catharsis.mixins.entity;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import net.minecraft.client.renderer.entity.EnderDragonRenderer;
+import net.minecraft.client.renderer.entity.state.EnderDragonRenderState;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(EnderDragonRenderer.class)
+public class EnderDragonRendererMixin {
+
+    @ModifyArgs(
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/OrderedSubmitNodeCollector;submitModel(Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/rendertype/RenderType;IIILnet/minecraft/client/renderer/texture/TextureAtlasSprite;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V",
+            ordinal = 2
+        ),
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/EnderDragonRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V"
+    )
+    public void catharsis$handleDragonTextureReplacement(Args args, @Local(argsOnly = true) EnderDragonRenderState state) {
+        CustomEntityModel customEntityModel = state.catharsis$getCustomEntityModel();
+
+        if (customEntityModel == null) return;
+
+        args.set(
+            3,
+            RenderTypes.entityCutoutNoCull(customEntityModel.getTexture())
+        );
+    }
+
+    @ModifyArgs(
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/OrderedSubmitNodeCollector;submitModel(Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/rendertype/RenderType;IIILnet/minecraft/client/renderer/texture/TextureAtlasSprite;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V",
+            ordinal = 1
+        ),
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/EnderDragonRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V"
+    )
+    public void catharsis$handleDragonTextureReplacementDecal(Args args, @Local(argsOnly = true) EnderDragonRenderState state) {
+        CustomEntityModel customEntityModel = state.catharsis$getCustomEntityModel();
+
+        if (customEntityModel == null) return;
+
+        args.set(
+            3,
+            RenderTypes.entityDecal(customEntityModel.getTexture())
+        );
+    }
+}

--- a/versions/1.21.11/src/main/java/me/owdding/catharsis/mixins/entity/LivingEntityRendererMixin.java
+++ b/versions/1.21.11/src/main/java/me/owdding/catharsis/mixins/entity/LivingEntityRendererMixin.java
@@ -1,0 +1,104 @@
+//~ named_identifier
+package me.owdding.catharsis.mixins.entity;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.vertex.PoseStack;
+import me.owdding.catharsis.features.entity.models.CustomEntityModel;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.client.renderer.entity.state.ArmorStandRenderState;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.client.renderer.state.CameraRenderState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(LivingEntityRenderer.class)
+public abstract class LivingEntityRendererMixin<S extends LivingEntityRenderState, M extends EntityModel<? super S>> {
+
+    @Shadow
+    protected abstract boolean isBodyVisible(S renderState);
+
+    @Shadow
+    protected M model;
+
+    @WrapMethod(
+       method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V"
+    )
+    private void catharsis$swapOutModel(S renderState, PoseStack poseStack, SubmitNodeCollector nodeCollector, CameraRenderState cameraRenderState, Operation<Void> original) {
+        M originalModel = this.model;
+
+        var customModel = renderState.catharsis$getCustomEntityModel();
+
+        if (customModel != null && customModel.getModel() != null && model instanceof EntityModel<? super S> entityModel) {
+            //noinspection unchecked
+            this.model = (M) customModel.replaceModel(entityModel);
+        }
+
+        original.call(renderState, poseStack, nodeCollector, cameraRenderState);
+
+        this.model = originalModel;
+    }
+
+    @ModifyArg(
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/SubmitNodeCollector;submitModel(Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/rendertype/RenderType;IIILnet/minecraft/client/renderer/texture/TextureAtlasSprite;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V"),
+        index = 3
+    )
+    private RenderType catharsis$modifyEntityTexture(RenderType renderType, @Local(argsOnly = true) S renderState) {
+        var customModel = renderState.catharsis$getCustomEntityModel();
+
+        if (customModel != null) {
+            return catharsis$createEntityTextureRenderType(renderState, customModel);
+        }
+
+        return renderType;
+    }
+
+    @WrapWithCondition(
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/layers/RenderLayer;submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/EntityRenderState;FF)V")
+    )
+    private boolean catharsis$modifyEntityLayers(RenderLayer<S, M> instance, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int light, EntityRenderState entityRenderState, float yRot, float xRot) {
+        var customModel = entityRenderState.catharsis$getCustomEntityModel();
+
+        return customModel == null;
+    }
+
+    @Unique
+    private RenderType catharsis$createEntityTextureRenderType(S renderState, CustomEntityModel customEntityModel) {
+        boolean bodyVisible = isBodyVisible(renderState);
+        boolean spectatorVisible = !bodyVisible && !renderState.isInvisibleToPlayer;
+        boolean isArmorStandMarker = renderState instanceof ArmorStandRenderState armorStandRenderState && armorStandRenderState.isMarker;
+        var texture = customEntityModel.getTexture();
+
+        if (isArmorStandMarker) {
+            if (spectatorVisible) {
+                return RenderTypes.entityTranslucent(texture, false);
+            }
+            if (bodyVisible) {
+                return RenderTypes.entityCutoutNoCull(texture, false);
+            }
+        }
+
+        if (spectatorVisible) {
+            return RenderTypes.itemEntityTranslucentCull(texture);
+        }
+
+        if (bodyVisible) {
+            return model.renderType(texture);
+        }
+
+        return RenderTypes.outline(texture);
+    }
+}


### PR DESCRIPTION
### Additions
- Allow 3rd party mods to add their own custom item models, enabling resourcepacks to retexture them.
- Add a way to stop slots being clickable.
- Customize a Item lore background.
- Add 3d model and custom texture support for entities.

### Changes
- A few optimization changes.
- Allow overwriting of repo defined guis.

### Fixes
- Fixed pack detection failing when there is an (1) between .cats and .zip.
- Conflicts with client side items in some mods.