### PR TITLE
fix: mods folder path in dev env

### DIFF
--- a/buildSrc/src/main/kotlin/catharsis-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/catharsis-setup.gradle.kts
@@ -39,7 +39,7 @@ loom.apply {
     runConfigs["client"].apply {
         ideConfigGenerated(true)
         runDir = "../../run"
-        vmArg("-Dfabric.modsFolder=" + '"' + rootProject.projectDir.resolve("run/${mcVersion}Mods").absolutePath + '"')
+        vmArg("-Dfabric.modsFolder=${rootProject.projectDir.resolve("run/${mcVersion}Mods").absolutePath}")
     }
 
     accessWidenerPath.set(accessWidenerFile)
@@ -227,4 +227,3 @@ autoMixins {
     projectName = "catharsis"
     mixinExtrasVersion = "0.5.0"
 }
-


### PR DESCRIPTION
It was trying to do this:
```
Uncaught exception in thread "main"
java.lang.RuntimeException: Could not create directory /Users/luna/src/catharsis/run/"/Users/luna/src/catharsis/run/261Mods"
	at net.fabricmc.loader.impl.discovery.DirectoryModCandidateFinder.findCandidates(DirectoryModCandidateFinder.java:48)
	at net.fabricmc.loader.impl.discovery.ModDiscoverer.discoverMods(ModDiscoverer.java:111)
	at net.fabricmc.loader.impl.FabricLoaderImpl.setup(FabricLoaderImpl.java:222)
	at net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:199)
	at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:142)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:66)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86)
Caused by: java.nio.file.NoSuchFileException: /Users/luna/src/catharsis/run/"/Users/luna/src/catharsis/run/261Mods"
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:418)
	at java.base/java.nio.file.Files.createDirectory(Files.java:647)
	at net.fabricmc.loader.impl.discovery.DirectoryModCandidateFinder.findCandidates(DirectoryModCandidateFinder.java:45)
	... 7 more
```

Only tested on macOS. Tested with a space in the path as well.