### PR TITLE
repo: update `skill_generator` script to account for "new" layout

### DIFF
--- a/repo/guis/classes/archer.json
+++ b/repo/guis/classes/archer.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/start_down",
+      "id": "skyblock_gui:classes/archer/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/start_down",
+      "id": "skyblock_gui:classes/archer/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/start_down",
+      "id": "skyblock_gui:classes/archer/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Archer Level 1",
               "Archer Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 2",
-              "Archer Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 2",
-              "Archer Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 2",
-              "Archer Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 3",
-              "Archer Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 3",
-              "Archer Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 3",
-              "Archer Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 4",
-              "Archer Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 4",
-              "Archer Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 4",
-              "Archer Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:classes/archer/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 2",
+              "Archer Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 2",
+              "Archer Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 2",
+              "Archer Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 3",
+              "Archer Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 3",
+              "Archer Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 3",
+              "Archer Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 4",
+              "Archer Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 4",
+              "Archer Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 4",
+              "Archer Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/left_up",
+      "id": "skyblock_gui:classes/archer/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/left_up",
+      "id": "skyblock_gui:classes/archer/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 6",
-              "Archer Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 6",
-              "Archer Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 6",
-              "Archer Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 7",
-              "Archer Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 7",
-              "Archer Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 7",
-              "Archer Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 8",
-              "Archer Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 8",
-              "Archer Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 8",
-              "Archer Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/archer/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Archer Level 9",
-              "Archer Level IX"
+              "Archer Level 6",
+              "Archer Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Archer Level 6",
+              "Archer Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 6",
+              "Archer Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 7",
+              "Archer Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 7",
+              "Archer Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 7",
+              "Archer Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 8",
+              "Archer Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 8",
+              "Archer Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 8",
+              "Archer Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Archer Level 9",
               "Archer Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/left_right",
+      "id": "skyblock_gui:classes/archer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 9",
+              "Archer Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/left_down",
+      "id": "skyblock_gui:classes/archer/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/left_down",
+      "id": "skyblock_gui:classes/archer/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/left_down",
+      "id": "skyblock_gui:classes/archer/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 11",
-              "Archer Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 11",
-              "Archer Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 11",
-              "Archer Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 12",
-              "Archer Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 12",
-              "Archer Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 12",
-              "Archer Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 13",
-              "Archer Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 13",
-              "Archer Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 13",
-              "Archer Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/archer/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Archer Level 14",
-              "Archer Level XIV"
+              "Archer Level 11",
+              "Archer Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Archer Level 11",
+              "Archer Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 11",
+              "Archer Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 12",
+              "Archer Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 12",
+              "Archer Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 12",
+              "Archer Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 13",
+              "Archer Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 13",
+              "Archer Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 13",
+              "Archer Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Archer Level 14",
               "Archer Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/left_right",
+      "id": "skyblock_gui:classes/archer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 14",
+              "Archer Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/left_up",
+      "id": "skyblock_gui:classes/archer/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/left_up",
+      "id": "skyblock_gui:classes/archer/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/left_up",
+      "id": "skyblock_gui:classes/archer/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 16",
-              "Archer Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 16",
-              "Archer Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 16",
-              "Archer Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 17",
-              "Archer Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 17",
-              "Archer Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 17",
-              "Archer Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 18",
-              "Archer Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 18",
-              "Archer Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 18",
-              "Archer Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/archer/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Archer Level 19",
-              "Archer Level XIX"
+              "Archer Level 16",
+              "Archer Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Archer Level 19",
-              "Archer Level XIX"
+              "Archer Level 16",
+              "Archer Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Archer Level 19",
-              "Archer Level XIX"
+              "Archer Level 16",
+              "Archer Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:bow"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 20",
-              "Archer Level XX"
+              "Archer Level 17",
+              "Archer Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Archer Level 20",
-              "Archer Level XX"
+              "Archer Level 17",
+              "Archer Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Archer Level 20",
-              "Archer Level XX"
+              "Archer Level 17",
+              "Archer Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Archer Level 21",
-              "Archer Level XXI"
+              "Archer Level 18",
+              "Archer Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Archer Level 21",
-              "Archer Level XXI"
+              "Archer Level 18",
+              "Archer Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Archer Level 21",
-              "Archer Level XXI"
+              "Archer Level 18",
+              "Archer Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Archer Level 22",
-              "Archer Level XXII"
+              "Archer Level 19",
+              "Archer Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Archer Level 22",
-              "Archer Level XXII"
+              "Archer Level 19",
+              "Archer Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Archer Level 22",
-              "Archer Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 23",
-              "Archer Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 23",
-              "Archer Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 23",
-              "Archer Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 24",
-              "Archer Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 24",
-              "Archer Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 24",
-              "Archer Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:bow"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 25",
-              "Archer Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 25",
-              "Archer Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 25",
-              "Archer Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 26",
-              "Archer Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 26",
-              "Archer Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 26",
-              "Archer Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 27",
-              "Archer Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 27",
-              "Archer Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Archer Level 27",
-              "Archer Level XXVII"
+              "Archer Level 19",
+              "Archer Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:bow"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 28",
-              "Archer Level XXVIII"
+              "Archer Level 20",
+              "Archer Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Archer Level 28",
-              "Archer Level XXVIII"
+              "Archer Level 20",
+              "Archer Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Archer Level 28",
-              "Archer Level XXVIII"
+              "Archer Level 20",
+              "Archer Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Archer Level 29",
-              "Archer Level XXIX"
+              "Archer Level 21",
+              "Archer Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Archer Level 29",
-              "Archer Level XXIX"
+              "Archer Level 21",
+              "Archer Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Archer Level 29",
-              "Archer Level XXIX"
+              "Archer Level 21",
+              "Archer Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:bow"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 30",
-              "Archer Level XXX"
+              "Archer Level 22",
+              "Archer Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Archer Level 30",
-              "Archer Level XXX"
+              "Archer Level 22",
+              "Archer Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Archer Level 30",
-              "Archer Level XXX"
+              "Archer Level 22",
+              "Archer Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Archer Level 31",
-              "Archer Level XXXI"
+              "Archer Level 23",
+              "Archer Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Archer Level 31",
-              "Archer Level XXXI"
+              "Archer Level 23",
+              "Archer Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Archer Level 31",
-              "Archer Level XXXI"
+              "Archer Level 23",
+              "Archer Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Archer Level 32",
-              "Archer Level XXXII"
+              "Archer Level 24",
+              "Archer Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Archer Level 32",
-              "Archer Level XXXII"
+              "Archer Level 24",
+              "Archer Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Archer Level 32",
-              "Archer Level XXXII"
+              "Archer Level 24",
+              "Archer Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:bow"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 33",
-              "Archer Level XXXIII"
+              "Archer Level 25",
+              "Archer Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Archer Level 33",
-              "Archer Level XXXIII"
+              "Archer Level 25",
+              "Archer Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Archer Level 33",
-              "Archer Level XXXIII"
+              "Archer Level 25",
+              "Archer Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Archer Level 34",
-              "Archer Level XXXIV"
+              "Archer Level 26",
+              "Archer Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Archer Level 34",
-              "Archer Level XXXIV"
+              "Archer Level 26",
+              "Archer Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Archer Level 34",
-              "Archer Level XXXIV"
+              "Archer Level 26",
+              "Archer Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:bow"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 35",
-              "Archer Level XXXV"
+              "Archer Level 27",
+              "Archer Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Archer Level 35",
-              "Archer Level XXXV"
+              "Archer Level 27",
+              "Archer Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Archer Level 35",
-              "Archer Level XXXV"
+              "Archer Level 27",
+              "Archer Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Archer Level 36",
-              "Archer Level XXXVI"
+              "Archer Level 28",
+              "Archer Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Archer Level 36",
-              "Archer Level XXXVI"
+              "Archer Level 28",
+              "Archer Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Archer Level 36",
-              "Archer Level XXXVI"
+              "Archer Level 28",
+              "Archer Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Archer Level 37",
-              "Archer Level XXXVII"
+              "Archer Level 29",
+              "Archer Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Archer Level 37",
-              "Archer Level XXXVII"
+              "Archer Level 29",
+              "Archer Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Archer Level 37",
-              "Archer Level XXXVII"
+              "Archer Level 29",
+              "Archer Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:bow"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 38",
-              "Archer Level XXXVIII"
+              "Archer Level 30",
+              "Archer Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Archer Level 38",
-              "Archer Level XXXVIII"
+              "Archer Level 30",
+              "Archer Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Archer Level 38",
-              "Archer Level XXXVIII"
+              "Archer Level 30",
+              "Archer Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Archer Level 39",
-              "Archer Level XXXIX"
+              "Archer Level 31",
+              "Archer Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Archer Level 39",
-              "Archer Level XXXIX"
+              "Archer Level 31",
+              "Archer Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Archer Level 39",
-              "Archer Level XXXIX"
+              "Archer Level 31",
+              "Archer Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:bow"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 40",
-              "Archer Level XL"
+              "Archer Level 32",
+              "Archer Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Archer Level 40",
-              "Archer Level XL"
+              "Archer Level 32",
+              "Archer Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Archer Level 40",
-              "Archer Level XL"
+              "Archer Level 32",
+              "Archer Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Archer Level 41",
-              "Archer Level XLI"
+              "Archer Level 33",
+              "Archer Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Archer Level 41",
-              "Archer Level XLI"
+              "Archer Level 33",
+              "Archer Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Archer Level 41",
-              "Archer Level XLI"
+              "Archer Level 33",
+              "Archer Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Archer Level 42",
-              "Archer Level XLII"
+              "Archer Level 34",
+              "Archer Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Archer Level 42",
-              "Archer Level XLII"
+              "Archer Level 34",
+              "Archer Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Archer Level 42",
-              "Archer Level XLII"
+              "Archer Level 34",
+              "Archer Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:bow"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Archer Level 43",
-              "Archer Level XLIII"
+              "Archer Level 35",
+              "Archer Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Archer Level 35",
+              "Archer Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 35",
+              "Archer Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 36",
+              "Archer Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 36",
+              "Archer Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 36",
+              "Archer Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 37",
+              "Archer Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 37",
+              "Archer Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 37",
+              "Archer Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 38",
+              "Archer Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 38",
+              "Archer Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 38",
+              "Archer Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 39",
+              "Archer Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 39",
+              "Archer Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 39",
+              "Archer Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:bow"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 40",
+              "Archer Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 40",
+              "Archer Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 40",
+              "Archer Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 41",
+              "Archer Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 41",
+              "Archer Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 41",
+              "Archer Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 42",
+              "Archer Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 42",
+              "Archer Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 42",
+              "Archer Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Archer Level 43",
               "Archer Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/down_right",
+      "id": "skyblock_gui:classes/archer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Archer Level 43",
+              "Archer Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/left_right",
+      "id": "skyblock_gui:classes/archer/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/left_right",
+      "id": "skyblock_gui:classes/archer/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/left_right",
+      "id": "skyblock_gui:classes/archer/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/left_down",
+      "id": "skyblock_gui:classes/archer/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/left_down",
+      "id": "skyblock_gui:classes/archer/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/left_down",
+      "id": "skyblock_gui:classes/archer/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
+      "id": "skyblock_gui:classes/archer/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
+      "id": "skyblock_gui:classes/archer/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
+      "id": "skyblock_gui:classes/archer/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocked/up_down",
+      "id": "skyblock_gui:classes/archer/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/unlocking/up_down",
+      "id": "skyblock_gui:classes/archer/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/archer/locked/up_down",
+      "id": "skyblock_gui:classes/archer/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -3044,6 +3044,75 @@
               "Archer Level 50",
               "Archer Level L"
             ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/class_pasives",
+      "target": {
+        "conditions": [
+          {
+            "slot": 39,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": [
+              "minecraft:splash_potion",
+              "minecraft:blaze_rod",
+              "minecraft:iron_sword",
+              "minecraft:bow",
+              "minecraft:leather_chestplate"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Class Passives",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/dungeon_orb_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 40,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Dungeon Orb Abilities",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/archer/ghost_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 41,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Ghost Abilities",
             "mode": "equals",
             "type": "catharsis:name"
           }

--- a/repo/guis/classes/berserk.json
+++ b/repo/guis/classes/berserk.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/start_down",
+      "id": "skyblock_gui:classes/berserk/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/start_down",
+      "id": "skyblock_gui:classes/berserk/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/start_down",
+      "id": "skyblock_gui:classes/berserk/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Berserk Level 1",
               "Berserk Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 2",
-              "Berserk Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 2",
-              "Berserk Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 2",
-              "Berserk Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 3",
-              "Berserk Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 3",
-              "Berserk Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 3",
-              "Berserk Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 4",
-              "Berserk Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 4",
-              "Berserk Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 4",
-              "Berserk Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:classes/berserk/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 2",
+              "Berserk Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 2",
+              "Berserk Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 2",
+              "Berserk Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 3",
+              "Berserk Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 3",
+              "Berserk Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 3",
+              "Berserk Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 4",
+              "Berserk Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 4",
+              "Berserk Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 4",
+              "Berserk Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/left_up",
+      "id": "skyblock_gui:classes/berserk/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/left_up",
+      "id": "skyblock_gui:classes/berserk/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 6",
-              "Berserk Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 6",
-              "Berserk Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 6",
-              "Berserk Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 7",
-              "Berserk Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 7",
-              "Berserk Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 7",
-              "Berserk Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 8",
-              "Berserk Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 8",
-              "Berserk Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 8",
-              "Berserk Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/berserk/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Berserk Level 9",
-              "Berserk Level IX"
+              "Berserk Level 6",
+              "Berserk Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Berserk Level 6",
+              "Berserk Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 6",
+              "Berserk Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 7",
+              "Berserk Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 7",
+              "Berserk Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 7",
+              "Berserk Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 8",
+              "Berserk Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 8",
+              "Berserk Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 8",
+              "Berserk Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Berserk Level 9",
               "Berserk Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/left_right",
+      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 9",
+              "Berserk Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/left_down",
+      "id": "skyblock_gui:classes/berserk/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/left_down",
+      "id": "skyblock_gui:classes/berserk/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/left_down",
+      "id": "skyblock_gui:classes/berserk/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 11",
-              "Berserk Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 11",
-              "Berserk Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 11",
-              "Berserk Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 12",
-              "Berserk Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 12",
-              "Berserk Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 12",
-              "Berserk Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 13",
-              "Berserk Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 13",
-              "Berserk Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 13",
-              "Berserk Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/berserk/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Berserk Level 14",
-              "Berserk Level XIV"
+              "Berserk Level 11",
+              "Berserk Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Berserk Level 11",
+              "Berserk Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 11",
+              "Berserk Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 12",
+              "Berserk Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 12",
+              "Berserk Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 12",
+              "Berserk Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 13",
+              "Berserk Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 13",
+              "Berserk Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 13",
+              "Berserk Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Berserk Level 14",
               "Berserk Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/left_right",
+      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 14",
+              "Berserk Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/left_up",
+      "id": "skyblock_gui:classes/berserk/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/left_up",
+      "id": "skyblock_gui:classes/berserk/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/left_up",
+      "id": "skyblock_gui:classes/berserk/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 16",
-              "Berserk Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 16",
-              "Berserk Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 16",
-              "Berserk Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 17",
-              "Berserk Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 17",
-              "Berserk Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 17",
-              "Berserk Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 18",
-              "Berserk Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 18",
-              "Berserk Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 18",
-              "Berserk Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/berserk/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Berserk Level 19",
-              "Berserk Level XIX"
+              "Berserk Level 16",
+              "Berserk Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Berserk Level 19",
-              "Berserk Level XIX"
+              "Berserk Level 16",
+              "Berserk Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Berserk Level 19",
-              "Berserk Level XIX"
+              "Berserk Level 16",
+              "Berserk Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_sword"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 20",
-              "Berserk Level XX"
+              "Berserk Level 17",
+              "Berserk Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Berserk Level 20",
-              "Berserk Level XX"
+              "Berserk Level 17",
+              "Berserk Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Berserk Level 20",
-              "Berserk Level XX"
+              "Berserk Level 17",
+              "Berserk Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Berserk Level 21",
-              "Berserk Level XXI"
+              "Berserk Level 18",
+              "Berserk Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Berserk Level 21",
-              "Berserk Level XXI"
+              "Berserk Level 18",
+              "Berserk Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Berserk Level 21",
-              "Berserk Level XXI"
+              "Berserk Level 18",
+              "Berserk Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Berserk Level 22",
-              "Berserk Level XXII"
+              "Berserk Level 19",
+              "Berserk Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Berserk Level 22",
-              "Berserk Level XXII"
+              "Berserk Level 19",
+              "Berserk Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Berserk Level 22",
-              "Berserk Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 23",
-              "Berserk Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 23",
-              "Berserk Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 23",
-              "Berserk Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 24",
-              "Berserk Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 24",
-              "Berserk Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 24",
-              "Berserk Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_sword"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 25",
-              "Berserk Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 25",
-              "Berserk Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 25",
-              "Berserk Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 26",
-              "Berserk Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 26",
-              "Berserk Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 26",
-              "Berserk Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 27",
-              "Berserk Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 27",
-              "Berserk Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Berserk Level 27",
-              "Berserk Level XXVII"
+              "Berserk Level 19",
+              "Berserk Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_sword"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 28",
-              "Berserk Level XXVIII"
+              "Berserk Level 20",
+              "Berserk Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Berserk Level 28",
-              "Berserk Level XXVIII"
+              "Berserk Level 20",
+              "Berserk Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Berserk Level 28",
-              "Berserk Level XXVIII"
+              "Berserk Level 20",
+              "Berserk Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Berserk Level 29",
-              "Berserk Level XXIX"
+              "Berserk Level 21",
+              "Berserk Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Berserk Level 29",
-              "Berserk Level XXIX"
+              "Berserk Level 21",
+              "Berserk Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Berserk Level 29",
-              "Berserk Level XXIX"
+              "Berserk Level 21",
+              "Berserk Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_sword"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 30",
-              "Berserk Level XXX"
+              "Berserk Level 22",
+              "Berserk Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Berserk Level 30",
-              "Berserk Level XXX"
+              "Berserk Level 22",
+              "Berserk Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Berserk Level 30",
-              "Berserk Level XXX"
+              "Berserk Level 22",
+              "Berserk Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Berserk Level 31",
-              "Berserk Level XXXI"
+              "Berserk Level 23",
+              "Berserk Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Berserk Level 31",
-              "Berserk Level XXXI"
+              "Berserk Level 23",
+              "Berserk Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Berserk Level 31",
-              "Berserk Level XXXI"
+              "Berserk Level 23",
+              "Berserk Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Berserk Level 32",
-              "Berserk Level XXXII"
+              "Berserk Level 24",
+              "Berserk Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Berserk Level 32",
-              "Berserk Level XXXII"
+              "Berserk Level 24",
+              "Berserk Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Berserk Level 32",
-              "Berserk Level XXXII"
+              "Berserk Level 24",
+              "Berserk Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_sword"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 33",
-              "Berserk Level XXXIII"
+              "Berserk Level 25",
+              "Berserk Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Berserk Level 33",
-              "Berserk Level XXXIII"
+              "Berserk Level 25",
+              "Berserk Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Berserk Level 33",
-              "Berserk Level XXXIII"
+              "Berserk Level 25",
+              "Berserk Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Berserk Level 34",
-              "Berserk Level XXXIV"
+              "Berserk Level 26",
+              "Berserk Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Berserk Level 34",
-              "Berserk Level XXXIV"
+              "Berserk Level 26",
+              "Berserk Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Berserk Level 34",
-              "Berserk Level XXXIV"
+              "Berserk Level 26",
+              "Berserk Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_sword"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 35",
-              "Berserk Level XXXV"
+              "Berserk Level 27",
+              "Berserk Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Berserk Level 35",
-              "Berserk Level XXXV"
+              "Berserk Level 27",
+              "Berserk Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Berserk Level 35",
-              "Berserk Level XXXV"
+              "Berserk Level 27",
+              "Berserk Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Berserk Level 36",
-              "Berserk Level XXXVI"
+              "Berserk Level 28",
+              "Berserk Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Berserk Level 36",
-              "Berserk Level XXXVI"
+              "Berserk Level 28",
+              "Berserk Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Berserk Level 36",
-              "Berserk Level XXXVI"
+              "Berserk Level 28",
+              "Berserk Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Berserk Level 37",
-              "Berserk Level XXXVII"
+              "Berserk Level 29",
+              "Berserk Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Berserk Level 37",
-              "Berserk Level XXXVII"
+              "Berserk Level 29",
+              "Berserk Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Berserk Level 37",
-              "Berserk Level XXXVII"
+              "Berserk Level 29",
+              "Berserk Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_sword"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 38",
-              "Berserk Level XXXVIII"
+              "Berserk Level 30",
+              "Berserk Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Berserk Level 38",
-              "Berserk Level XXXVIII"
+              "Berserk Level 30",
+              "Berserk Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Berserk Level 38",
-              "Berserk Level XXXVIII"
+              "Berserk Level 30",
+              "Berserk Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Berserk Level 39",
-              "Berserk Level XXXIX"
+              "Berserk Level 31",
+              "Berserk Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Berserk Level 39",
-              "Berserk Level XXXIX"
+              "Berserk Level 31",
+              "Berserk Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Berserk Level 39",
-              "Berserk Level XXXIX"
+              "Berserk Level 31",
+              "Berserk Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_sword"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 40",
-              "Berserk Level XL"
+              "Berserk Level 32",
+              "Berserk Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Berserk Level 40",
-              "Berserk Level XL"
+              "Berserk Level 32",
+              "Berserk Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Berserk Level 40",
-              "Berserk Level XL"
+              "Berserk Level 32",
+              "Berserk Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Berserk Level 41",
-              "Berserk Level XLI"
+              "Berserk Level 33",
+              "Berserk Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Berserk Level 41",
-              "Berserk Level XLI"
+              "Berserk Level 33",
+              "Berserk Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Berserk Level 41",
-              "Berserk Level XLI"
+              "Berserk Level 33",
+              "Berserk Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Berserk Level 42",
-              "Berserk Level XLII"
+              "Berserk Level 34",
+              "Berserk Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Berserk Level 42",
-              "Berserk Level XLII"
+              "Berserk Level 34",
+              "Berserk Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Berserk Level 42",
-              "Berserk Level XLII"
+              "Berserk Level 34",
+              "Berserk Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_sword"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Berserk Level 43",
-              "Berserk Level XLIII"
+              "Berserk Level 35",
+              "Berserk Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Berserk Level 35",
+              "Berserk Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 35",
+              "Berserk Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 36",
+              "Berserk Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 36",
+              "Berserk Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 36",
+              "Berserk Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 37",
+              "Berserk Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 37",
+              "Berserk Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 37",
+              "Berserk Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 38",
+              "Berserk Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 38",
+              "Berserk Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 38",
+              "Berserk Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 39",
+              "Berserk Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 39",
+              "Berserk Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 39",
+              "Berserk Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_sword"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 40",
+              "Berserk Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 40",
+              "Berserk Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 40",
+              "Berserk Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 41",
+              "Berserk Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 41",
+              "Berserk Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 41",
+              "Berserk Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 42",
+              "Berserk Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 42",
+              "Berserk Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 42",
+              "Berserk Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Berserk Level 43",
               "Berserk Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/down_right",
+      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Berserk Level 43",
+              "Berserk Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/left_right",
+      "id": "skyblock_gui:classes/berserk/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/left_right",
+      "id": "skyblock_gui:classes/berserk/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/left_right",
+      "id": "skyblock_gui:classes/berserk/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/left_down",
+      "id": "skyblock_gui:classes/berserk/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/left_down",
+      "id": "skyblock_gui:classes/berserk/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/left_down",
+      "id": "skyblock_gui:classes/berserk/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
+      "id": "skyblock_gui:classes/berserk/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
+      "id": "skyblock_gui:classes/berserk/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
+      "id": "skyblock_gui:classes/berserk/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocked/up_down",
+      "id": "skyblock_gui:classes/berserk/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/unlocking/up_down",
+      "id": "skyblock_gui:classes/berserk/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/berserk/locked/up_down",
+      "id": "skyblock_gui:classes/berserk/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -3044,6 +3044,75 @@
               "Berserk Level 50",
               "Berserk Level L"
             ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/class_pasives",
+      "target": {
+        "conditions": [
+          {
+            "slot": 39,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": [
+              "minecraft:splash_potion",
+              "minecraft:blaze_rod",
+              "minecraft:iron_sword",
+              "minecraft:bow",
+              "minecraft:leather_chestplate"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Class Passives",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/dungeon_orb_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 40,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Dungeon Orb Abilities",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/berserk/ghost_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 41,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Ghost Abilities",
             "mode": "equals",
             "type": "catharsis:name"
           }

--- a/repo/guis/classes/healer.json
+++ b/repo/guis/classes/healer.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/start_down",
+      "id": "skyblock_gui:classes/healer/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/start_down",
+      "id": "skyblock_gui:classes/healer/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/start_down",
+      "id": "skyblock_gui:classes/healer/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Healer Level 1",
               "Healer Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 2",
-              "Healer Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 2",
-              "Healer Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 2",
-              "Healer Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 3",
-              "Healer Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 3",
-              "Healer Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 3",
-              "Healer Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 4",
-              "Healer Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 4",
-              "Healer Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 4",
-              "Healer Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:classes/healer/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 2",
+              "Healer Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 2",
+              "Healer Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 2",
+              "Healer Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 3",
+              "Healer Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 3",
+              "Healer Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 3",
+              "Healer Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 4",
+              "Healer Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 4",
+              "Healer Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 4",
+              "Healer Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/left_up",
+      "id": "skyblock_gui:classes/healer/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/left_up",
+      "id": "skyblock_gui:classes/healer/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 6",
-              "Healer Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 6",
-              "Healer Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 6",
-              "Healer Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 7",
-              "Healer Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 7",
-              "Healer Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 7",
-              "Healer Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 8",
-              "Healer Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 8",
-              "Healer Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 8",
-              "Healer Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/healer/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Healer Level 9",
-              "Healer Level IX"
+              "Healer Level 6",
+              "Healer Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Healer Level 6",
+              "Healer Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 6",
+              "Healer Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 7",
+              "Healer Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 7",
+              "Healer Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 7",
+              "Healer Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 8",
+              "Healer Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 8",
+              "Healer Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 8",
+              "Healer Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Healer Level 9",
               "Healer Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/left_right",
+      "id": "skyblock_gui:classes/healer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 9",
+              "Healer Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/left_down",
+      "id": "skyblock_gui:classes/healer/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/left_down",
+      "id": "skyblock_gui:classes/healer/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/left_down",
+      "id": "skyblock_gui:classes/healer/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 11",
-              "Healer Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 11",
-              "Healer Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 11",
-              "Healer Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 12",
-              "Healer Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 12",
-              "Healer Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 12",
-              "Healer Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 13",
-              "Healer Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 13",
-              "Healer Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 13",
-              "Healer Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/healer/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Healer Level 14",
-              "Healer Level XIV"
+              "Healer Level 11",
+              "Healer Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Healer Level 11",
+              "Healer Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 11",
+              "Healer Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 12",
+              "Healer Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 12",
+              "Healer Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 12",
+              "Healer Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 13",
+              "Healer Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 13",
+              "Healer Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 13",
+              "Healer Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Healer Level 14",
               "Healer Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/left_right",
+      "id": "skyblock_gui:classes/healer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 14",
+              "Healer Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/left_up",
+      "id": "skyblock_gui:classes/healer/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/left_up",
+      "id": "skyblock_gui:classes/healer/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/left_up",
+      "id": "skyblock_gui:classes/healer/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 16",
-              "Healer Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 16",
-              "Healer Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 16",
-              "Healer Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 17",
-              "Healer Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 17",
-              "Healer Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 17",
-              "Healer Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 18",
-              "Healer Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 18",
-              "Healer Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 18",
-              "Healer Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/healer/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Healer Level 19",
-              "Healer Level XIX"
+              "Healer Level 16",
+              "Healer Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Healer Level 19",
-              "Healer Level XIX"
+              "Healer Level 16",
+              "Healer Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Healer Level 19",
-              "Healer Level XIX"
+              "Healer Level 16",
+              "Healer Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:splash_potion"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 20",
-              "Healer Level XX"
+              "Healer Level 17",
+              "Healer Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Healer Level 20",
-              "Healer Level XX"
+              "Healer Level 17",
+              "Healer Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Healer Level 20",
-              "Healer Level XX"
+              "Healer Level 17",
+              "Healer Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Healer Level 21",
-              "Healer Level XXI"
+              "Healer Level 18",
+              "Healer Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Healer Level 21",
-              "Healer Level XXI"
+              "Healer Level 18",
+              "Healer Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Healer Level 21",
-              "Healer Level XXI"
+              "Healer Level 18",
+              "Healer Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Healer Level 22",
-              "Healer Level XXII"
+              "Healer Level 19",
+              "Healer Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Healer Level 22",
-              "Healer Level XXII"
+              "Healer Level 19",
+              "Healer Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Healer Level 22",
-              "Healer Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 23",
-              "Healer Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 23",
-              "Healer Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 23",
-              "Healer Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 24",
-              "Healer Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 24",
-              "Healer Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 24",
-              "Healer Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:splash_potion"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 25",
-              "Healer Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 25",
-              "Healer Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 25",
-              "Healer Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 26",
-              "Healer Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 26",
-              "Healer Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 26",
-              "Healer Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 27",
-              "Healer Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 27",
-              "Healer Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Healer Level 27",
-              "Healer Level XXVII"
+              "Healer Level 19",
+              "Healer Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:splash_potion"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 28",
-              "Healer Level XXVIII"
+              "Healer Level 20",
+              "Healer Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Healer Level 28",
-              "Healer Level XXVIII"
+              "Healer Level 20",
+              "Healer Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Healer Level 28",
-              "Healer Level XXVIII"
+              "Healer Level 20",
+              "Healer Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Healer Level 29",
-              "Healer Level XXIX"
+              "Healer Level 21",
+              "Healer Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Healer Level 29",
-              "Healer Level XXIX"
+              "Healer Level 21",
+              "Healer Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Healer Level 29",
-              "Healer Level XXIX"
+              "Healer Level 21",
+              "Healer Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:splash_potion"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 30",
-              "Healer Level XXX"
+              "Healer Level 22",
+              "Healer Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Healer Level 30",
-              "Healer Level XXX"
+              "Healer Level 22",
+              "Healer Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Healer Level 30",
-              "Healer Level XXX"
+              "Healer Level 22",
+              "Healer Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Healer Level 31",
-              "Healer Level XXXI"
+              "Healer Level 23",
+              "Healer Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Healer Level 31",
-              "Healer Level XXXI"
+              "Healer Level 23",
+              "Healer Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Healer Level 31",
-              "Healer Level XXXI"
+              "Healer Level 23",
+              "Healer Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Healer Level 32",
-              "Healer Level XXXII"
+              "Healer Level 24",
+              "Healer Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Healer Level 32",
-              "Healer Level XXXII"
+              "Healer Level 24",
+              "Healer Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Healer Level 32",
-              "Healer Level XXXII"
+              "Healer Level 24",
+              "Healer Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:splash_potion"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 33",
-              "Healer Level XXXIII"
+              "Healer Level 25",
+              "Healer Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Healer Level 33",
-              "Healer Level XXXIII"
+              "Healer Level 25",
+              "Healer Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Healer Level 33",
-              "Healer Level XXXIII"
+              "Healer Level 25",
+              "Healer Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Healer Level 34",
-              "Healer Level XXXIV"
+              "Healer Level 26",
+              "Healer Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Healer Level 34",
-              "Healer Level XXXIV"
+              "Healer Level 26",
+              "Healer Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Healer Level 34",
-              "Healer Level XXXIV"
+              "Healer Level 26",
+              "Healer Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:splash_potion"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 35",
-              "Healer Level XXXV"
+              "Healer Level 27",
+              "Healer Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Healer Level 35",
-              "Healer Level XXXV"
+              "Healer Level 27",
+              "Healer Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Healer Level 35",
-              "Healer Level XXXV"
+              "Healer Level 27",
+              "Healer Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Healer Level 36",
-              "Healer Level XXXVI"
+              "Healer Level 28",
+              "Healer Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Healer Level 36",
-              "Healer Level XXXVI"
+              "Healer Level 28",
+              "Healer Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Healer Level 36",
-              "Healer Level XXXVI"
+              "Healer Level 28",
+              "Healer Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Healer Level 37",
-              "Healer Level XXXVII"
+              "Healer Level 29",
+              "Healer Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Healer Level 37",
-              "Healer Level XXXVII"
+              "Healer Level 29",
+              "Healer Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Healer Level 37",
-              "Healer Level XXXVII"
+              "Healer Level 29",
+              "Healer Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:splash_potion"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 38",
-              "Healer Level XXXVIII"
+              "Healer Level 30",
+              "Healer Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Healer Level 38",
-              "Healer Level XXXVIII"
+              "Healer Level 30",
+              "Healer Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Healer Level 38",
-              "Healer Level XXXVIII"
+              "Healer Level 30",
+              "Healer Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Healer Level 39",
-              "Healer Level XXXIX"
+              "Healer Level 31",
+              "Healer Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Healer Level 39",
-              "Healer Level XXXIX"
+              "Healer Level 31",
+              "Healer Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Healer Level 39",
-              "Healer Level XXXIX"
+              "Healer Level 31",
+              "Healer Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:splash_potion"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 40",
-              "Healer Level XL"
+              "Healer Level 32",
+              "Healer Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Healer Level 40",
-              "Healer Level XL"
+              "Healer Level 32",
+              "Healer Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Healer Level 40",
-              "Healer Level XL"
+              "Healer Level 32",
+              "Healer Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Healer Level 41",
-              "Healer Level XLI"
+              "Healer Level 33",
+              "Healer Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Healer Level 41",
-              "Healer Level XLI"
+              "Healer Level 33",
+              "Healer Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Healer Level 41",
-              "Healer Level XLI"
+              "Healer Level 33",
+              "Healer Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Healer Level 42",
-              "Healer Level XLII"
+              "Healer Level 34",
+              "Healer Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Healer Level 42",
-              "Healer Level XLII"
+              "Healer Level 34",
+              "Healer Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Healer Level 42",
-              "Healer Level XLII"
+              "Healer Level 34",
+              "Healer Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:splash_potion"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Healer Level 43",
-              "Healer Level XLIII"
+              "Healer Level 35",
+              "Healer Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Healer Level 35",
+              "Healer Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 35",
+              "Healer Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 36",
+              "Healer Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 36",
+              "Healer Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 36",
+              "Healer Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 37",
+              "Healer Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 37",
+              "Healer Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 37",
+              "Healer Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 38",
+              "Healer Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 38",
+              "Healer Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 38",
+              "Healer Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 39",
+              "Healer Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 39",
+              "Healer Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 39",
+              "Healer Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:splash_potion"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 40",
+              "Healer Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 40",
+              "Healer Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 40",
+              "Healer Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 41",
+              "Healer Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 41",
+              "Healer Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 41",
+              "Healer Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 42",
+              "Healer Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 42",
+              "Healer Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 42",
+              "Healer Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Healer Level 43",
               "Healer Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/down_right",
+      "id": "skyblock_gui:classes/healer/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Healer Level 43",
+              "Healer Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/left_right",
+      "id": "skyblock_gui:classes/healer/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/left_right",
+      "id": "skyblock_gui:classes/healer/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/left_right",
+      "id": "skyblock_gui:classes/healer/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/left_down",
+      "id": "skyblock_gui:classes/healer/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/left_down",
+      "id": "skyblock_gui:classes/healer/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/left_down",
+      "id": "skyblock_gui:classes/healer/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
+      "id": "skyblock_gui:classes/healer/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
+      "id": "skyblock_gui:classes/healer/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
+      "id": "skyblock_gui:classes/healer/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocked/up_down",
+      "id": "skyblock_gui:classes/healer/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/unlocking/up_down",
+      "id": "skyblock_gui:classes/healer/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/healer/locked/up_down",
+      "id": "skyblock_gui:classes/healer/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -3044,6 +3044,75 @@
               "Healer Level 50",
               "Healer Level L"
             ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/class_pasives",
+      "target": {
+        "conditions": [
+          {
+            "slot": 39,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": [
+              "minecraft:splash_potion",
+              "minecraft:blaze_rod",
+              "minecraft:iron_sword",
+              "minecraft:bow",
+              "minecraft:leather_chestplate"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Class Passives",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/dungeon_orb_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 40,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Dungeon Orb Abilities",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/healer/ghost_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 41,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Ghost Abilities",
             "mode": "equals",
             "type": "catharsis:name"
           }

--- a/repo/guis/classes/mage.json
+++ b/repo/guis/classes/mage.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/start_down",
+      "id": "skyblock_gui:classes/mage/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/start_down",
+      "id": "skyblock_gui:classes/mage/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/start_down",
+      "id": "skyblock_gui:classes/mage/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Mage Level 1",
               "Mage Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 2",
-              "Mage Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 2",
-              "Mage Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 2",
-              "Mage Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 3",
-              "Mage Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 3",
-              "Mage Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 3",
-              "Mage Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 4",
-              "Mage Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 4",
-              "Mage Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 4",
-              "Mage Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:classes/mage/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 2",
+              "Mage Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 2",
+              "Mage Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 2",
+              "Mage Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 3",
+              "Mage Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 3",
+              "Mage Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 3",
+              "Mage Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 4",
+              "Mage Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 4",
+              "Mage Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 4",
+              "Mage Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/left_up",
+      "id": "skyblock_gui:classes/mage/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/left_up",
+      "id": "skyblock_gui:classes/mage/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 6",
-              "Mage Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 6",
-              "Mage Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 6",
-              "Mage Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 7",
-              "Mage Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 7",
-              "Mage Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 7",
-              "Mage Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 8",
-              "Mage Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 8",
-              "Mage Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 8",
-              "Mage Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/mage/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Mage Level 9",
-              "Mage Level IX"
+              "Mage Level 6",
+              "Mage Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Mage Level 6",
+              "Mage Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 6",
+              "Mage Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 7",
+              "Mage Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 7",
+              "Mage Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 7",
+              "Mage Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 8",
+              "Mage Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 8",
+              "Mage Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 8",
+              "Mage Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Mage Level 9",
               "Mage Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/left_right",
+      "id": "skyblock_gui:classes/mage/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 9",
+              "Mage Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/left_down",
+      "id": "skyblock_gui:classes/mage/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/left_down",
+      "id": "skyblock_gui:classes/mage/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/left_down",
+      "id": "skyblock_gui:classes/mage/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 11",
-              "Mage Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 11",
-              "Mage Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 11",
-              "Mage Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 12",
-              "Mage Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 12",
-              "Mage Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 12",
-              "Mage Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 13",
-              "Mage Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 13",
-              "Mage Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 13",
-              "Mage Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/mage/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Mage Level 14",
-              "Mage Level XIV"
+              "Mage Level 11",
+              "Mage Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Mage Level 11",
+              "Mage Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 11",
+              "Mage Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 12",
+              "Mage Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 12",
+              "Mage Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 12",
+              "Mage Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 13",
+              "Mage Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 13",
+              "Mage Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 13",
+              "Mage Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Mage Level 14",
               "Mage Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/left_right",
+      "id": "skyblock_gui:classes/mage/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 14",
+              "Mage Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/left_up",
+      "id": "skyblock_gui:classes/mage/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/left_up",
+      "id": "skyblock_gui:classes/mage/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/left_up",
+      "id": "skyblock_gui:classes/mage/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 16",
-              "Mage Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 16",
-              "Mage Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 16",
-              "Mage Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 17",
-              "Mage Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 17",
-              "Mage Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 17",
-              "Mage Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 18",
-              "Mage Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 18",
-              "Mage Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 18",
-              "Mage Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/mage/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Mage Level 19",
-              "Mage Level XIX"
+              "Mage Level 16",
+              "Mage Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Mage Level 19",
-              "Mage Level XIX"
+              "Mage Level 16",
+              "Mage Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Mage Level 19",
-              "Mage Level XIX"
+              "Mage Level 16",
+              "Mage Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 20",
-              "Mage Level XX"
+              "Mage Level 17",
+              "Mage Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Mage Level 20",
-              "Mage Level XX"
+              "Mage Level 17",
+              "Mage Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Mage Level 20",
-              "Mage Level XX"
+              "Mage Level 17",
+              "Mage Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Mage Level 21",
-              "Mage Level XXI"
+              "Mage Level 18",
+              "Mage Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Mage Level 21",
-              "Mage Level XXI"
+              "Mage Level 18",
+              "Mage Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Mage Level 21",
-              "Mage Level XXI"
+              "Mage Level 18",
+              "Mage Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Mage Level 22",
-              "Mage Level XXII"
+              "Mage Level 19",
+              "Mage Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Mage Level 22",
-              "Mage Level XXII"
+              "Mage Level 19",
+              "Mage Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Mage Level 22",
-              "Mage Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 23",
-              "Mage Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 23",
-              "Mage Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 23",
-              "Mage Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 24",
-              "Mage Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 24",
-              "Mage Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 24",
-              "Mage Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 25",
-              "Mage Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 25",
-              "Mage Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 25",
-              "Mage Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 26",
-              "Mage Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 26",
-              "Mage Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 26",
-              "Mage Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 27",
-              "Mage Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 27",
-              "Mage Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mage Level 27",
-              "Mage Level XXVII"
+              "Mage Level 19",
+              "Mage Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 28",
-              "Mage Level XXVIII"
+              "Mage Level 20",
+              "Mage Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Mage Level 28",
-              "Mage Level XXVIII"
+              "Mage Level 20",
+              "Mage Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Mage Level 28",
-              "Mage Level XXVIII"
+              "Mage Level 20",
+              "Mage Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Mage Level 29",
-              "Mage Level XXIX"
+              "Mage Level 21",
+              "Mage Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Mage Level 29",
-              "Mage Level XXIX"
+              "Mage Level 21",
+              "Mage Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Mage Level 29",
-              "Mage Level XXIX"
+              "Mage Level 21",
+              "Mage Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 30",
-              "Mage Level XXX"
+              "Mage Level 22",
+              "Mage Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Mage Level 30",
-              "Mage Level XXX"
+              "Mage Level 22",
+              "Mage Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Mage Level 30",
-              "Mage Level XXX"
+              "Mage Level 22",
+              "Mage Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Mage Level 31",
-              "Mage Level XXXI"
+              "Mage Level 23",
+              "Mage Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Mage Level 31",
-              "Mage Level XXXI"
+              "Mage Level 23",
+              "Mage Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Mage Level 31",
-              "Mage Level XXXI"
+              "Mage Level 23",
+              "Mage Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Mage Level 32",
-              "Mage Level XXXII"
+              "Mage Level 24",
+              "Mage Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Mage Level 32",
-              "Mage Level XXXII"
+              "Mage Level 24",
+              "Mage Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Mage Level 32",
-              "Mage Level XXXII"
+              "Mage Level 24",
+              "Mage Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 33",
-              "Mage Level XXXIII"
+              "Mage Level 25",
+              "Mage Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Mage Level 33",
-              "Mage Level XXXIII"
+              "Mage Level 25",
+              "Mage Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Mage Level 33",
-              "Mage Level XXXIII"
+              "Mage Level 25",
+              "Mage Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Mage Level 34",
-              "Mage Level XXXIV"
+              "Mage Level 26",
+              "Mage Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Mage Level 34",
-              "Mage Level XXXIV"
+              "Mage Level 26",
+              "Mage Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Mage Level 34",
-              "Mage Level XXXIV"
+              "Mage Level 26",
+              "Mage Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 35",
-              "Mage Level XXXV"
+              "Mage Level 27",
+              "Mage Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Mage Level 35",
-              "Mage Level XXXV"
+              "Mage Level 27",
+              "Mage Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Mage Level 35",
-              "Mage Level XXXV"
+              "Mage Level 27",
+              "Mage Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Mage Level 36",
-              "Mage Level XXXVI"
+              "Mage Level 28",
+              "Mage Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Mage Level 36",
-              "Mage Level XXXVI"
+              "Mage Level 28",
+              "Mage Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Mage Level 36",
-              "Mage Level XXXVI"
+              "Mage Level 28",
+              "Mage Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Mage Level 37",
-              "Mage Level XXXVII"
+              "Mage Level 29",
+              "Mage Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Mage Level 37",
-              "Mage Level XXXVII"
+              "Mage Level 29",
+              "Mage Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Mage Level 37",
-              "Mage Level XXXVII"
+              "Mage Level 29",
+              "Mage Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 38",
-              "Mage Level XXXVIII"
+              "Mage Level 30",
+              "Mage Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Mage Level 38",
-              "Mage Level XXXVIII"
+              "Mage Level 30",
+              "Mage Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Mage Level 38",
-              "Mage Level XXXVIII"
+              "Mage Level 30",
+              "Mage Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Mage Level 39",
-              "Mage Level XXXIX"
+              "Mage Level 31",
+              "Mage Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Mage Level 39",
-              "Mage Level XXXIX"
+              "Mage Level 31",
+              "Mage Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Mage Level 39",
-              "Mage Level XXXIX"
+              "Mage Level 31",
+              "Mage Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 40",
-              "Mage Level XL"
+              "Mage Level 32",
+              "Mage Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Mage Level 40",
-              "Mage Level XL"
+              "Mage Level 32",
+              "Mage Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Mage Level 40",
-              "Mage Level XL"
+              "Mage Level 32",
+              "Mage Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Mage Level 41",
-              "Mage Level XLI"
+              "Mage Level 33",
+              "Mage Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Mage Level 41",
-              "Mage Level XLI"
+              "Mage Level 33",
+              "Mage Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Mage Level 41",
-              "Mage Level XLI"
+              "Mage Level 33",
+              "Mage Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Mage Level 42",
-              "Mage Level XLII"
+              "Mage Level 34",
+              "Mage Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Mage Level 42",
-              "Mage Level XLII"
+              "Mage Level 34",
+              "Mage Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Mage Level 42",
-              "Mage Level XLII"
+              "Mage Level 34",
+              "Mage Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mage Level 43",
-              "Mage Level XLIII"
+              "Mage Level 35",
+              "Mage Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Mage Level 35",
+              "Mage Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 35",
+              "Mage Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 36",
+              "Mage Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 36",
+              "Mage Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 36",
+              "Mage Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 37",
+              "Mage Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 37",
+              "Mage Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 37",
+              "Mage Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 38",
+              "Mage Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 38",
+              "Mage Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 38",
+              "Mage Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 39",
+              "Mage Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 39",
+              "Mage Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 39",
+              "Mage Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 40",
+              "Mage Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 40",
+              "Mage Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 40",
+              "Mage Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 41",
+              "Mage Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 41",
+              "Mage Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 41",
+              "Mage Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 42",
+              "Mage Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 42",
+              "Mage Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 42",
+              "Mage Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Mage Level 43",
               "Mage Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/down_right",
+      "id": "skyblock_gui:classes/mage/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mage Level 43",
+              "Mage Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/left_right",
+      "id": "skyblock_gui:classes/mage/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/left_right",
+      "id": "skyblock_gui:classes/mage/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/left_right",
+      "id": "skyblock_gui:classes/mage/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/left_down",
+      "id": "skyblock_gui:classes/mage/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/left_down",
+      "id": "skyblock_gui:classes/mage/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/left_down",
+      "id": "skyblock_gui:classes/mage/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
+      "id": "skyblock_gui:classes/mage/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
+      "id": "skyblock_gui:classes/mage/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
+      "id": "skyblock_gui:classes/mage/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocked/up_down",
+      "id": "skyblock_gui:classes/mage/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/unlocking/up_down",
+      "id": "skyblock_gui:classes/mage/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/mage/locked/up_down",
+      "id": "skyblock_gui:classes/mage/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -3044,6 +3044,75 @@
               "Mage Level 50",
               "Mage Level L"
             ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/class_pasives",
+      "target": {
+        "conditions": [
+          {
+            "slot": 39,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": [
+              "minecraft:splash_potion",
+              "minecraft:blaze_rod",
+              "minecraft:iron_sword",
+              "minecraft:bow",
+              "minecraft:leather_chestplate"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Class Passives",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/dungeon_orb_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 40,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Dungeon Orb Abilities",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/mage/ghost_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 41,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Ghost Abilities",
             "mode": "equals",
             "type": "catharsis:name"
           }

--- a/repo/guis/classes/tank.json
+++ b/repo/guis/classes/tank.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/start_down",
+      "id": "skyblock_gui:classes/tank/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/start_down",
+      "id": "skyblock_gui:classes/tank/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/start_down",
+      "id": "skyblock_gui:classes/tank/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Tank Level 1",
               "Tank Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 2",
-              "Tank Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 2",
-              "Tank Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 2",
-              "Tank Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 3",
-              "Tank Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 3",
-              "Tank Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 3",
-              "Tank Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 4",
-              "Tank Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 4",
-              "Tank Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 4",
-              "Tank Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:classes/tank/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 2",
+              "Tank Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 2",
+              "Tank Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 2",
+              "Tank Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 3",
+              "Tank Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 3",
+              "Tank Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 3",
+              "Tank Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 4",
+              "Tank Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 4",
+              "Tank Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 4",
+              "Tank Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/left_up",
+      "id": "skyblock_gui:classes/tank/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/left_up",
+      "id": "skyblock_gui:classes/tank/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 6",
-              "Tank Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 6",
-              "Tank Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 6",
-              "Tank Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 7",
-              "Tank Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 7",
-              "Tank Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 7",
-              "Tank Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 8",
-              "Tank Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 8",
-              "Tank Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 8",
-              "Tank Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/tank/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Tank Level 9",
-              "Tank Level IX"
+              "Tank Level 6",
+              "Tank Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Tank Level 6",
+              "Tank Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 6",
+              "Tank Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 7",
+              "Tank Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 7",
+              "Tank Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 7",
+              "Tank Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 8",
+              "Tank Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 8",
+              "Tank Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 8",
+              "Tank Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Tank Level 9",
               "Tank Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/left_right",
+      "id": "skyblock_gui:classes/tank/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 9",
+              "Tank Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/left_down",
+      "id": "skyblock_gui:classes/tank/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/left_down",
+      "id": "skyblock_gui:classes/tank/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/left_down",
+      "id": "skyblock_gui:classes/tank/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 11",
-              "Tank Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 11",
-              "Tank Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 11",
-              "Tank Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 12",
-              "Tank Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 12",
-              "Tank Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 12",
-              "Tank Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 13",
-              "Tank Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 13",
-              "Tank Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 13",
-              "Tank Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/tank/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Tank Level 14",
-              "Tank Level XIV"
+              "Tank Level 11",
+              "Tank Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Tank Level 11",
+              "Tank Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 11",
+              "Tank Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 12",
+              "Tank Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 12",
+              "Tank Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 12",
+              "Tank Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 13",
+              "Tank Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 13",
+              "Tank Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 13",
+              "Tank Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Tank Level 14",
               "Tank Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/left_right",
+      "id": "skyblock_gui:classes/tank/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 14",
+              "Tank Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/left_up",
+      "id": "skyblock_gui:classes/tank/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/left_up",
+      "id": "skyblock_gui:classes/tank/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/left_up",
+      "id": "skyblock_gui:classes/tank/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 16",
-              "Tank Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 16",
-              "Tank Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 16",
-              "Tank Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 17",
-              "Tank Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 17",
-              "Tank Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 17",
-              "Tank Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 18",
-              "Tank Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 18",
-              "Tank Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 18",
-              "Tank Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:classes/tank/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Tank Level 19",
-              "Tank Level XIX"
+              "Tank Level 16",
+              "Tank Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Tank Level 19",
-              "Tank Level XIX"
+              "Tank Level 16",
+              "Tank Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Tank Level 19",
-              "Tank Level XIX"
+              "Tank Level 16",
+              "Tank Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:leather_chestplate"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 20",
-              "Tank Level XX"
+              "Tank Level 17",
+              "Tank Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Tank Level 20",
-              "Tank Level XX"
+              "Tank Level 17",
+              "Tank Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Tank Level 20",
-              "Tank Level XX"
+              "Tank Level 17",
+              "Tank Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Tank Level 21",
-              "Tank Level XXI"
+              "Tank Level 18",
+              "Tank Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Tank Level 21",
-              "Tank Level XXI"
+              "Tank Level 18",
+              "Tank Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Tank Level 21",
-              "Tank Level XXI"
+              "Tank Level 18",
+              "Tank Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Tank Level 22",
-              "Tank Level XXII"
+              "Tank Level 19",
+              "Tank Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Tank Level 22",
-              "Tank Level XXII"
+              "Tank Level 19",
+              "Tank Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Tank Level 22",
-              "Tank Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 23",
-              "Tank Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 23",
-              "Tank Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 23",
-              "Tank Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 24",
-              "Tank Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 24",
-              "Tank Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 24",
-              "Tank Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:leather_chestplate"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 25",
-              "Tank Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 25",
-              "Tank Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 25",
-              "Tank Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 26",
-              "Tank Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 26",
-              "Tank Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 26",
-              "Tank Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 27",
-              "Tank Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 27",
-              "Tank Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Tank Level 27",
-              "Tank Level XXVII"
+              "Tank Level 19",
+              "Tank Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:leather_chestplate"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 28",
-              "Tank Level XXVIII"
+              "Tank Level 20",
+              "Tank Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Tank Level 28",
-              "Tank Level XXVIII"
+              "Tank Level 20",
+              "Tank Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Tank Level 28",
-              "Tank Level XXVIII"
+              "Tank Level 20",
+              "Tank Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Tank Level 29",
-              "Tank Level XXIX"
+              "Tank Level 21",
+              "Tank Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Tank Level 29",
-              "Tank Level XXIX"
+              "Tank Level 21",
+              "Tank Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Tank Level 29",
-              "Tank Level XXIX"
+              "Tank Level 21",
+              "Tank Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:leather_chestplate"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 30",
-              "Tank Level XXX"
+              "Tank Level 22",
+              "Tank Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Tank Level 30",
-              "Tank Level XXX"
+              "Tank Level 22",
+              "Tank Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Tank Level 30",
-              "Tank Level XXX"
+              "Tank Level 22",
+              "Tank Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Tank Level 31",
-              "Tank Level XXXI"
+              "Tank Level 23",
+              "Tank Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Tank Level 31",
-              "Tank Level XXXI"
+              "Tank Level 23",
+              "Tank Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Tank Level 31",
-              "Tank Level XXXI"
+              "Tank Level 23",
+              "Tank Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Tank Level 32",
-              "Tank Level XXXII"
+              "Tank Level 24",
+              "Tank Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Tank Level 32",
-              "Tank Level XXXII"
+              "Tank Level 24",
+              "Tank Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Tank Level 32",
-              "Tank Level XXXII"
+              "Tank Level 24",
+              "Tank Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:leather_chestplate"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 33",
-              "Tank Level XXXIII"
+              "Tank Level 25",
+              "Tank Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Tank Level 33",
-              "Tank Level XXXIII"
+              "Tank Level 25",
+              "Tank Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Tank Level 33",
-              "Tank Level XXXIII"
+              "Tank Level 25",
+              "Tank Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Tank Level 34",
-              "Tank Level XXXIV"
+              "Tank Level 26",
+              "Tank Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Tank Level 34",
-              "Tank Level XXXIV"
+              "Tank Level 26",
+              "Tank Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Tank Level 34",
-              "Tank Level XXXIV"
+              "Tank Level 26",
+              "Tank Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:leather_chestplate"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 35",
-              "Tank Level XXXV"
+              "Tank Level 27",
+              "Tank Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Tank Level 35",
-              "Tank Level XXXV"
+              "Tank Level 27",
+              "Tank Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Tank Level 35",
-              "Tank Level XXXV"
+              "Tank Level 27",
+              "Tank Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Tank Level 36",
-              "Tank Level XXXVI"
+              "Tank Level 28",
+              "Tank Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Tank Level 36",
-              "Tank Level XXXVI"
+              "Tank Level 28",
+              "Tank Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Tank Level 36",
-              "Tank Level XXXVI"
+              "Tank Level 28",
+              "Tank Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Tank Level 37",
-              "Tank Level XXXVII"
+              "Tank Level 29",
+              "Tank Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Tank Level 37",
-              "Tank Level XXXVII"
+              "Tank Level 29",
+              "Tank Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Tank Level 37",
-              "Tank Level XXXVII"
+              "Tank Level 29",
+              "Tank Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:leather_chestplate"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 38",
-              "Tank Level XXXVIII"
+              "Tank Level 30",
+              "Tank Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Tank Level 38",
-              "Tank Level XXXVIII"
+              "Tank Level 30",
+              "Tank Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Tank Level 38",
-              "Tank Level XXXVIII"
+              "Tank Level 30",
+              "Tank Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Tank Level 39",
-              "Tank Level XXXIX"
+              "Tank Level 31",
+              "Tank Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Tank Level 39",
-              "Tank Level XXXIX"
+              "Tank Level 31",
+              "Tank Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Tank Level 39",
-              "Tank Level XXXIX"
+              "Tank Level 31",
+              "Tank Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:leather_chestplate"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 40",
-              "Tank Level XL"
+              "Tank Level 32",
+              "Tank Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Tank Level 40",
-              "Tank Level XL"
+              "Tank Level 32",
+              "Tank Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Tank Level 40",
-              "Tank Level XL"
+              "Tank Level 32",
+              "Tank Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Tank Level 41",
-              "Tank Level XLI"
+              "Tank Level 33",
+              "Tank Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Tank Level 41",
-              "Tank Level XLI"
+              "Tank Level 33",
+              "Tank Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Tank Level 41",
-              "Tank Level XLI"
+              "Tank Level 33",
+              "Tank Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Tank Level 42",
-              "Tank Level XLII"
+              "Tank Level 34",
+              "Tank Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Tank Level 42",
-              "Tank Level XLII"
+              "Tank Level 34",
+              "Tank Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Tank Level 42",
-              "Tank Level XLII"
+              "Tank Level 34",
+              "Tank Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:leather_chestplate"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Tank Level 43",
-              "Tank Level XLIII"
+              "Tank Level 35",
+              "Tank Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Tank Level 35",
+              "Tank Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 35",
+              "Tank Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 36",
+              "Tank Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 36",
+              "Tank Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 36",
+              "Tank Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 37",
+              "Tank Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 37",
+              "Tank Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 37",
+              "Tank Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 38",
+              "Tank Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 38",
+              "Tank Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 38",
+              "Tank Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 39",
+              "Tank Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 39",
+              "Tank Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 39",
+              "Tank Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:leather_chestplate"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 40",
+              "Tank Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 40",
+              "Tank Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 40",
+              "Tank Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 41",
+              "Tank Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 41",
+              "Tank Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 41",
+              "Tank Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 42",
+              "Tank Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 42",
+              "Tank Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 42",
+              "Tank Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Tank Level 43",
               "Tank Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/down_right",
+      "id": "skyblock_gui:classes/tank/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Tank Level 43",
+              "Tank Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/left_right",
+      "id": "skyblock_gui:classes/tank/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/left_right",
+      "id": "skyblock_gui:classes/tank/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/left_right",
+      "id": "skyblock_gui:classes/tank/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/left_down",
+      "id": "skyblock_gui:classes/tank/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/left_down",
+      "id": "skyblock_gui:classes/tank/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/left_down",
+      "id": "skyblock_gui:classes/tank/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
+      "id": "skyblock_gui:classes/tank/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
+      "id": "skyblock_gui:classes/tank/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
+      "id": "skyblock_gui:classes/tank/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocked/up_down",
+      "id": "skyblock_gui:classes/tank/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/unlocking/up_down",
+      "id": "skyblock_gui:classes/tank/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:classes/tank/locked/up_down",
+      "id": "skyblock_gui:classes/tank/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -3044,6 +3044,75 @@
               "Tank Level 50",
               "Tank Level L"
             ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/class_pasives",
+      "target": {
+        "conditions": [
+          {
+            "slot": 39,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": [
+              "minecraft:splash_potion",
+              "minecraft:blaze_rod",
+              "minecraft:iron_sword",
+              "minecraft:bow",
+              "minecraft:leather_chestplate"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Class Passives",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/dungeon_orb_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 40,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Dungeon Orb Abilities",
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:classes/tank/ghost_abilities",
+      "target": {
+        "conditions": [
+          {
+            "slot": 41,
+            "type": "catharsis:slot"
+          },
+          {
+            "items": "minecraft:player_head",
+            "type": "catharsis:item"
+          },
+          {
+            "name": "Ghost Abilities",
             "mode": "equals",
             "type": "catharsis:name"
           }

--- a/repo/guis/generic/generic.json
+++ b/repo/guis/generic/generic.json
@@ -153,6 +153,30 @@
       }
     },
     {
+      "id": "skyblock_gui:generic/navigation/scroll_left",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Scroll Left"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/re-center",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Re-Center"
+      }
+    },
+    {
+      "id": "skyblock_gui:generic/navigation/scroll_right",
+      "target": {
+        "type": "name",
+        "mode": "equals",
+        "name": "Scroll Right"
+      }
+    },
+    {
       "id": "skyblock_gui:generic/navigation/previous_page",
       "target": {
         "type": "name",

--- a/repo/guis/skills/alchemy.json
+++ b/repo/guis/skills/alchemy.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/start_down",
+      "id": "skyblock_gui:skills/alchemy/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/start_down",
+      "id": "skyblock_gui:skills/alchemy/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/start_down",
+      "id": "skyblock_gui:skills/alchemy/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Alchemy Level 1",
               "Alchemy Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 2",
-              "Alchemy Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 2",
-              "Alchemy Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 2",
-              "Alchemy Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 3",
-              "Alchemy Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 3",
-              "Alchemy Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 3",
-              "Alchemy Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 4",
-              "Alchemy Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 4",
-              "Alchemy Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 4",
-              "Alchemy Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:skills/alchemy/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 2",
+              "Alchemy Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 2",
+              "Alchemy Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 2",
+              "Alchemy Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 3",
+              "Alchemy Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 3",
+              "Alchemy Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 3",
+              "Alchemy Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 4",
+              "Alchemy Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 4",
+              "Alchemy Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 4",
+              "Alchemy Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/left_up",
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/left_up",
+      "id": "skyblock_gui:skills/alchemy/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 6",
-              "Alchemy Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 6",
-              "Alchemy Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 6",
-              "Alchemy Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 7",
-              "Alchemy Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 7",
-              "Alchemy Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 7",
-              "Alchemy Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 8",
-              "Alchemy Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 8",
-              "Alchemy Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 8",
-              "Alchemy Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Alchemy Level 9",
-              "Alchemy Level IX"
+              "Alchemy Level 6",
+              "Alchemy Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Alchemy Level 6",
+              "Alchemy Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 6",
+              "Alchemy Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 7",
+              "Alchemy Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 7",
+              "Alchemy Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 7",
+              "Alchemy Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 8",
+              "Alchemy Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 8",
+              "Alchemy Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 8",
+              "Alchemy Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Alchemy Level 9",
               "Alchemy Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/left_right",
+      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 9",
+              "Alchemy Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/left_down",
+      "id": "skyblock_gui:skills/alchemy/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/left_down",
+      "id": "skyblock_gui:skills/alchemy/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/left_down",
+      "id": "skyblock_gui:skills/alchemy/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 11",
-              "Alchemy Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 11",
-              "Alchemy Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 11",
-              "Alchemy Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 12",
-              "Alchemy Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 12",
-              "Alchemy Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 12",
-              "Alchemy Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 13",
-              "Alchemy Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 13",
-              "Alchemy Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 13",
-              "Alchemy Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Alchemy Level 14",
-              "Alchemy Level XIV"
+              "Alchemy Level 11",
+              "Alchemy Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Alchemy Level 11",
+              "Alchemy Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 11",
+              "Alchemy Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 12",
+              "Alchemy Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 12",
+              "Alchemy Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 12",
+              "Alchemy Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 13",
+              "Alchemy Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 13",
+              "Alchemy Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 13",
+              "Alchemy Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Alchemy Level 14",
               "Alchemy Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/left_right",
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 14",
+              "Alchemy Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/left_up",
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/left_up",
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/left_up",
+      "id": "skyblock_gui:skills/alchemy/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 16",
-              "Alchemy Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 16",
-              "Alchemy Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 16",
-              "Alchemy Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 17",
-              "Alchemy Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 17",
-              "Alchemy Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 17",
-              "Alchemy Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 18",
-              "Alchemy Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 18",
-              "Alchemy Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 18",
-              "Alchemy Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Alchemy Level 19",
-              "Alchemy Level XIX"
+              "Alchemy Level 16",
+              "Alchemy Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Alchemy Level 19",
-              "Alchemy Level XIX"
+              "Alchemy Level 16",
+              "Alchemy Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Alchemy Level 19",
-              "Alchemy Level XIX"
+              "Alchemy Level 16",
+              "Alchemy Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 20",
-              "Alchemy Level XX"
+              "Alchemy Level 17",
+              "Alchemy Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Alchemy Level 20",
-              "Alchemy Level XX"
+              "Alchemy Level 17",
+              "Alchemy Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Alchemy Level 20",
-              "Alchemy Level XX"
+              "Alchemy Level 17",
+              "Alchemy Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Alchemy Level 21",
-              "Alchemy Level XXI"
+              "Alchemy Level 18",
+              "Alchemy Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Alchemy Level 21",
-              "Alchemy Level XXI"
+              "Alchemy Level 18",
+              "Alchemy Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Alchemy Level 21",
-              "Alchemy Level XXI"
+              "Alchemy Level 18",
+              "Alchemy Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Alchemy Level 22",
-              "Alchemy Level XXII"
+              "Alchemy Level 19",
+              "Alchemy Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Alchemy Level 22",
-              "Alchemy Level XXII"
+              "Alchemy Level 19",
+              "Alchemy Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Alchemy Level 22",
-              "Alchemy Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 23",
-              "Alchemy Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 23",
-              "Alchemy Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 23",
-              "Alchemy Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 24",
-              "Alchemy Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 24",
-              "Alchemy Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 24",
-              "Alchemy Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 25",
-              "Alchemy Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 25",
-              "Alchemy Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 25",
-              "Alchemy Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 26",
-              "Alchemy Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 26",
-              "Alchemy Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 26",
-              "Alchemy Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 27",
-              "Alchemy Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 27",
-              "Alchemy Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Alchemy Level 27",
-              "Alchemy Level XXVII"
+              "Alchemy Level 19",
+              "Alchemy Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 28",
-              "Alchemy Level XXVIII"
+              "Alchemy Level 20",
+              "Alchemy Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Alchemy Level 28",
-              "Alchemy Level XXVIII"
+              "Alchemy Level 20",
+              "Alchemy Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Alchemy Level 28",
-              "Alchemy Level XXVIII"
+              "Alchemy Level 20",
+              "Alchemy Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Alchemy Level 29",
-              "Alchemy Level XXIX"
+              "Alchemy Level 21",
+              "Alchemy Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Alchemy Level 29",
-              "Alchemy Level XXIX"
+              "Alchemy Level 21",
+              "Alchemy Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Alchemy Level 29",
-              "Alchemy Level XXIX"
+              "Alchemy Level 21",
+              "Alchemy Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 30",
-              "Alchemy Level XXX"
+              "Alchemy Level 22",
+              "Alchemy Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Alchemy Level 30",
-              "Alchemy Level XXX"
+              "Alchemy Level 22",
+              "Alchemy Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Alchemy Level 30",
-              "Alchemy Level XXX"
+              "Alchemy Level 22",
+              "Alchemy Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Alchemy Level 31",
-              "Alchemy Level XXXI"
+              "Alchemy Level 23",
+              "Alchemy Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Alchemy Level 31",
-              "Alchemy Level XXXI"
+              "Alchemy Level 23",
+              "Alchemy Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Alchemy Level 31",
-              "Alchemy Level XXXI"
+              "Alchemy Level 23",
+              "Alchemy Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Alchemy Level 32",
-              "Alchemy Level XXXII"
+              "Alchemy Level 24",
+              "Alchemy Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Alchemy Level 32",
-              "Alchemy Level XXXII"
+              "Alchemy Level 24",
+              "Alchemy Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Alchemy Level 32",
-              "Alchemy Level XXXII"
+              "Alchemy Level 24",
+              "Alchemy Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 33",
-              "Alchemy Level XXXIII"
+              "Alchemy Level 25",
+              "Alchemy Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Alchemy Level 33",
-              "Alchemy Level XXXIII"
+              "Alchemy Level 25",
+              "Alchemy Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Alchemy Level 33",
-              "Alchemy Level XXXIII"
+              "Alchemy Level 25",
+              "Alchemy Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Alchemy Level 34",
-              "Alchemy Level XXXIV"
+              "Alchemy Level 26",
+              "Alchemy Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Alchemy Level 34",
-              "Alchemy Level XXXIV"
+              "Alchemy Level 26",
+              "Alchemy Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Alchemy Level 34",
-              "Alchemy Level XXXIV"
+              "Alchemy Level 26",
+              "Alchemy Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 35",
-              "Alchemy Level XXXV"
+              "Alchemy Level 27",
+              "Alchemy Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Alchemy Level 35",
-              "Alchemy Level XXXV"
+              "Alchemy Level 27",
+              "Alchemy Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Alchemy Level 35",
-              "Alchemy Level XXXV"
+              "Alchemy Level 27",
+              "Alchemy Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Alchemy Level 36",
-              "Alchemy Level XXXVI"
+              "Alchemy Level 28",
+              "Alchemy Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Alchemy Level 36",
-              "Alchemy Level XXXVI"
+              "Alchemy Level 28",
+              "Alchemy Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Alchemy Level 36",
-              "Alchemy Level XXXVI"
+              "Alchemy Level 28",
+              "Alchemy Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Alchemy Level 37",
-              "Alchemy Level XXXVII"
+              "Alchemy Level 29",
+              "Alchemy Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Alchemy Level 37",
-              "Alchemy Level XXXVII"
+              "Alchemy Level 29",
+              "Alchemy Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Alchemy Level 37",
-              "Alchemy Level XXXVII"
+              "Alchemy Level 29",
+              "Alchemy Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 38",
-              "Alchemy Level XXXVIII"
+              "Alchemy Level 30",
+              "Alchemy Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Alchemy Level 38",
-              "Alchemy Level XXXVIII"
+              "Alchemy Level 30",
+              "Alchemy Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Alchemy Level 38",
-              "Alchemy Level XXXVIII"
+              "Alchemy Level 30",
+              "Alchemy Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Alchemy Level 39",
-              "Alchemy Level XXXIX"
+              "Alchemy Level 31",
+              "Alchemy Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Alchemy Level 39",
-              "Alchemy Level XXXIX"
+              "Alchemy Level 31",
+              "Alchemy Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Alchemy Level 39",
-              "Alchemy Level XXXIX"
+              "Alchemy Level 31",
+              "Alchemy Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_rod"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 40",
-              "Alchemy Level XL"
+              "Alchemy Level 32",
+              "Alchemy Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Alchemy Level 40",
-              "Alchemy Level XL"
+              "Alchemy Level 32",
+              "Alchemy Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Alchemy Level 40",
-              "Alchemy Level XL"
+              "Alchemy Level 32",
+              "Alchemy Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Alchemy Level 41",
-              "Alchemy Level XLI"
+              "Alchemy Level 33",
+              "Alchemy Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Alchemy Level 41",
-              "Alchemy Level XLI"
+              "Alchemy Level 33",
+              "Alchemy Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Alchemy Level 41",
-              "Alchemy Level XLI"
+              "Alchemy Level 33",
+              "Alchemy Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Alchemy Level 42",
-              "Alchemy Level XLII"
+              "Alchemy Level 34",
+              "Alchemy Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Alchemy Level 42",
-              "Alchemy Level XLII"
+              "Alchemy Level 34",
+              "Alchemy Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Alchemy Level 42",
-              "Alchemy Level XLII"
+              "Alchemy Level 34",
+              "Alchemy Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Alchemy Level 43",
-              "Alchemy Level XLIII"
+              "Alchemy Level 35",
+              "Alchemy Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Alchemy Level 35",
+              "Alchemy Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 35",
+              "Alchemy Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 36",
+              "Alchemy Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 36",
+              "Alchemy Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 36",
+              "Alchemy Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 37",
+              "Alchemy Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 37",
+              "Alchemy Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 37",
+              "Alchemy Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 38",
+              "Alchemy Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 38",
+              "Alchemy Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 38",
+              "Alchemy Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 39",
+              "Alchemy Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 39",
+              "Alchemy Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 39",
+              "Alchemy Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_rod"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 40",
+              "Alchemy Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 40",
+              "Alchemy Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 40",
+              "Alchemy Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 41",
+              "Alchemy Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 41",
+              "Alchemy Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 41",
+              "Alchemy Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 42",
+              "Alchemy Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 42",
+              "Alchemy Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 42",
+              "Alchemy Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Alchemy Level 43",
               "Alchemy Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/down_right",
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Alchemy Level 43",
+              "Alchemy Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/alchemy/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/left_right",
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/left_right",
+      "id": "skyblock_gui:skills/alchemy/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/left_down",
+      "id": "skyblock_gui:skills/alchemy/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/left_down",
+      "id": "skyblock_gui:skills/alchemy/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/left_down",
+      "id": "skyblock_gui:skills/alchemy/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
+      "id": "skyblock_gui:skills/alchemy/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocked/up_down",
+      "id": "skyblock_gui:skills/alchemy/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/unlocking/up_down",
+      "id": "skyblock_gui:skills/alchemy/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/alchemy/locked/up_down",
+      "id": "skyblock_gui:skills/alchemy/locked/left_down",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/carpentry.json
+++ b/repo/guis/skills/carpentry.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/start_down",
+      "id": "skyblock_gui:skills/carpentry/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/start_down",
+      "id": "skyblock_gui:skills/carpentry/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/start_down",
+      "id": "skyblock_gui:skills/carpentry/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Carpentry Level 1",
               "Carpentry Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 2",
-              "Carpentry Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 2",
-              "Carpentry Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 2",
-              "Carpentry Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 3",
-              "Carpentry Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 3",
-              "Carpentry Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 3",
-              "Carpentry Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 4",
-              "Carpentry Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 4",
-              "Carpentry Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 4",
-              "Carpentry Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:skills/carpentry/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 2",
+              "Carpentry Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 2",
+              "Carpentry Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 2",
+              "Carpentry Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 3",
+              "Carpentry Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 3",
+              "Carpentry Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 3",
+              "Carpentry Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 4",
+              "Carpentry Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 4",
+              "Carpentry Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 4",
+              "Carpentry Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/left_up",
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/left_up",
+      "id": "skyblock_gui:skills/carpentry/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 6",
-              "Carpentry Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 6",
-              "Carpentry Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 6",
-              "Carpentry Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 7",
-              "Carpentry Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 7",
-              "Carpentry Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 7",
-              "Carpentry Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 8",
-              "Carpentry Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 8",
-              "Carpentry Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 8",
-              "Carpentry Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Carpentry Level 9",
-              "Carpentry Level IX"
+              "Carpentry Level 6",
+              "Carpentry Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Carpentry Level 6",
+              "Carpentry Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 6",
+              "Carpentry Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 7",
+              "Carpentry Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 7",
+              "Carpentry Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 7",
+              "Carpentry Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 8",
+              "Carpentry Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 8",
+              "Carpentry Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 8",
+              "Carpentry Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Carpentry Level 9",
               "Carpentry Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/left_right",
+      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 9",
+              "Carpentry Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/left_down",
+      "id": "skyblock_gui:skills/carpentry/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/left_down",
+      "id": "skyblock_gui:skills/carpentry/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/left_down",
+      "id": "skyblock_gui:skills/carpentry/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 11",
-              "Carpentry Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 11",
-              "Carpentry Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 11",
-              "Carpentry Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 12",
-              "Carpentry Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 12",
-              "Carpentry Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 12",
-              "Carpentry Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 13",
-              "Carpentry Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 13",
-              "Carpentry Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 13",
-              "Carpentry Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Carpentry Level 14",
-              "Carpentry Level XIV"
+              "Carpentry Level 11",
+              "Carpentry Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Carpentry Level 11",
+              "Carpentry Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 11",
+              "Carpentry Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 12",
+              "Carpentry Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 12",
+              "Carpentry Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 12",
+              "Carpentry Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 13",
+              "Carpentry Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 13",
+              "Carpentry Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 13",
+              "Carpentry Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Carpentry Level 14",
               "Carpentry Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/left_right",
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 14",
+              "Carpentry Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/left_up",
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/left_up",
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/left_up",
+      "id": "skyblock_gui:skills/carpentry/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 16",
-              "Carpentry Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 16",
-              "Carpentry Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 16",
-              "Carpentry Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 17",
-              "Carpentry Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 17",
-              "Carpentry Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 17",
-              "Carpentry Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 18",
-              "Carpentry Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 18",
-              "Carpentry Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 18",
-              "Carpentry Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Carpentry Level 19",
-              "Carpentry Level XIX"
+              "Carpentry Level 16",
+              "Carpentry Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Carpentry Level 19",
-              "Carpentry Level XIX"
+              "Carpentry Level 16",
+              "Carpentry Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Carpentry Level 19",
-              "Carpentry Level XIX"
+              "Carpentry Level 16",
+              "Carpentry Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:armor_stand"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 20",
-              "Carpentry Level XX"
+              "Carpentry Level 17",
+              "Carpentry Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Carpentry Level 20",
-              "Carpentry Level XX"
+              "Carpentry Level 17",
+              "Carpentry Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Carpentry Level 20",
-              "Carpentry Level XX"
+              "Carpentry Level 17",
+              "Carpentry Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Carpentry Level 21",
-              "Carpentry Level XXI"
+              "Carpentry Level 18",
+              "Carpentry Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Carpentry Level 21",
-              "Carpentry Level XXI"
+              "Carpentry Level 18",
+              "Carpentry Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Carpentry Level 21",
-              "Carpentry Level XXI"
+              "Carpentry Level 18",
+              "Carpentry Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Carpentry Level 22",
-              "Carpentry Level XXII"
+              "Carpentry Level 19",
+              "Carpentry Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Carpentry Level 22",
-              "Carpentry Level XXII"
+              "Carpentry Level 19",
+              "Carpentry Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Carpentry Level 22",
-              "Carpentry Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 23",
-              "Carpentry Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 23",
-              "Carpentry Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 23",
-              "Carpentry Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 24",
-              "Carpentry Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 24",
-              "Carpentry Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 24",
-              "Carpentry Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:armor_stand"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 25",
-              "Carpentry Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 25",
-              "Carpentry Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 25",
-              "Carpentry Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 26",
-              "Carpentry Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 26",
-              "Carpentry Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 26",
-              "Carpentry Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 27",
-              "Carpentry Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 27",
-              "Carpentry Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Carpentry Level 27",
-              "Carpentry Level XXVII"
+              "Carpentry Level 19",
+              "Carpentry Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:armor_stand"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 28",
-              "Carpentry Level XXVIII"
+              "Carpentry Level 20",
+              "Carpentry Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Carpentry Level 28",
-              "Carpentry Level XXVIII"
+              "Carpentry Level 20",
+              "Carpentry Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Carpentry Level 28",
-              "Carpentry Level XXVIII"
+              "Carpentry Level 20",
+              "Carpentry Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Carpentry Level 29",
-              "Carpentry Level XXIX"
+              "Carpentry Level 21",
+              "Carpentry Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Carpentry Level 29",
-              "Carpentry Level XXIX"
+              "Carpentry Level 21",
+              "Carpentry Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Carpentry Level 29",
-              "Carpentry Level XXIX"
+              "Carpentry Level 21",
+              "Carpentry Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:armor_stand"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 30",
-              "Carpentry Level XXX"
+              "Carpentry Level 22",
+              "Carpentry Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Carpentry Level 30",
-              "Carpentry Level XXX"
+              "Carpentry Level 22",
+              "Carpentry Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Carpentry Level 30",
-              "Carpentry Level XXX"
+              "Carpentry Level 22",
+              "Carpentry Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Carpentry Level 31",
-              "Carpentry Level XXXI"
+              "Carpentry Level 23",
+              "Carpentry Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Carpentry Level 31",
-              "Carpentry Level XXXI"
+              "Carpentry Level 23",
+              "Carpentry Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Carpentry Level 31",
-              "Carpentry Level XXXI"
+              "Carpentry Level 23",
+              "Carpentry Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Carpentry Level 32",
-              "Carpentry Level XXXII"
+              "Carpentry Level 24",
+              "Carpentry Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Carpentry Level 32",
-              "Carpentry Level XXXII"
+              "Carpentry Level 24",
+              "Carpentry Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Carpentry Level 32",
-              "Carpentry Level XXXII"
+              "Carpentry Level 24",
+              "Carpentry Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:armor_stand"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 33",
-              "Carpentry Level XXXIII"
+              "Carpentry Level 25",
+              "Carpentry Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Carpentry Level 33",
-              "Carpentry Level XXXIII"
+              "Carpentry Level 25",
+              "Carpentry Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Carpentry Level 33",
-              "Carpentry Level XXXIII"
+              "Carpentry Level 25",
+              "Carpentry Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Carpentry Level 34",
-              "Carpentry Level XXXIV"
+              "Carpentry Level 26",
+              "Carpentry Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Carpentry Level 34",
-              "Carpentry Level XXXIV"
+              "Carpentry Level 26",
+              "Carpentry Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Carpentry Level 34",
-              "Carpentry Level XXXIV"
+              "Carpentry Level 26",
+              "Carpentry Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:armor_stand"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 35",
-              "Carpentry Level XXXV"
+              "Carpentry Level 27",
+              "Carpentry Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Carpentry Level 35",
-              "Carpentry Level XXXV"
+              "Carpentry Level 27",
+              "Carpentry Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Carpentry Level 35",
-              "Carpentry Level XXXV"
+              "Carpentry Level 27",
+              "Carpentry Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Carpentry Level 36",
-              "Carpentry Level XXXVI"
+              "Carpentry Level 28",
+              "Carpentry Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Carpentry Level 36",
-              "Carpentry Level XXXVI"
+              "Carpentry Level 28",
+              "Carpentry Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Carpentry Level 36",
-              "Carpentry Level XXXVI"
+              "Carpentry Level 28",
+              "Carpentry Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Carpentry Level 37",
-              "Carpentry Level XXXVII"
+              "Carpentry Level 29",
+              "Carpentry Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Carpentry Level 37",
-              "Carpentry Level XXXVII"
+              "Carpentry Level 29",
+              "Carpentry Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Carpentry Level 37",
-              "Carpentry Level XXXVII"
+              "Carpentry Level 29",
+              "Carpentry Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:armor_stand"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 38",
-              "Carpentry Level XXXVIII"
+              "Carpentry Level 30",
+              "Carpentry Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Carpentry Level 38",
-              "Carpentry Level XXXVIII"
+              "Carpentry Level 30",
+              "Carpentry Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Carpentry Level 38",
-              "Carpentry Level XXXVIII"
+              "Carpentry Level 30",
+              "Carpentry Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Carpentry Level 39",
-              "Carpentry Level XXXIX"
+              "Carpentry Level 31",
+              "Carpentry Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Carpentry Level 39",
-              "Carpentry Level XXXIX"
+              "Carpentry Level 31",
+              "Carpentry Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Carpentry Level 39",
-              "Carpentry Level XXXIX"
+              "Carpentry Level 31",
+              "Carpentry Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:armor_stand"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 40",
-              "Carpentry Level XL"
+              "Carpentry Level 32",
+              "Carpentry Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Carpentry Level 40",
-              "Carpentry Level XL"
+              "Carpentry Level 32",
+              "Carpentry Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Carpentry Level 40",
-              "Carpentry Level XL"
+              "Carpentry Level 32",
+              "Carpentry Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Carpentry Level 41",
-              "Carpentry Level XLI"
+              "Carpentry Level 33",
+              "Carpentry Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Carpentry Level 41",
-              "Carpentry Level XLI"
+              "Carpentry Level 33",
+              "Carpentry Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Carpentry Level 41",
-              "Carpentry Level XLI"
+              "Carpentry Level 33",
+              "Carpentry Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Carpentry Level 42",
-              "Carpentry Level XLII"
+              "Carpentry Level 34",
+              "Carpentry Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Carpentry Level 42",
-              "Carpentry Level XLII"
+              "Carpentry Level 34",
+              "Carpentry Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Carpentry Level 42",
-              "Carpentry Level XLII"
+              "Carpentry Level 34",
+              "Carpentry Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:armor_stand"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Carpentry Level 43",
-              "Carpentry Level XLIII"
+              "Carpentry Level 35",
+              "Carpentry Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Carpentry Level 35",
+              "Carpentry Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 35",
+              "Carpentry Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 36",
+              "Carpentry Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 36",
+              "Carpentry Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 36",
+              "Carpentry Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 37",
+              "Carpentry Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 37",
+              "Carpentry Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 37",
+              "Carpentry Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 38",
+              "Carpentry Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 38",
+              "Carpentry Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 38",
+              "Carpentry Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 39",
+              "Carpentry Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 39",
+              "Carpentry Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 39",
+              "Carpentry Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:armor_stand"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 40",
+              "Carpentry Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 40",
+              "Carpentry Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 40",
+              "Carpentry Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 41",
+              "Carpentry Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 41",
+              "Carpentry Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 41",
+              "Carpentry Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 42",
+              "Carpentry Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 42",
+              "Carpentry Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 42",
+              "Carpentry Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Carpentry Level 43",
               "Carpentry Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/down_right",
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Carpentry Level 43",
+              "Carpentry Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/carpentry/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/left_right",
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/left_right",
+      "id": "skyblock_gui:skills/carpentry/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/left_down",
+      "id": "skyblock_gui:skills/carpentry/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/left_down",
+      "id": "skyblock_gui:skills/carpentry/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/left_down",
+      "id": "skyblock_gui:skills/carpentry/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
+      "id": "skyblock_gui:skills/carpentry/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocked/up_down",
+      "id": "skyblock_gui:skills/carpentry/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/unlocking/up_down",
+      "id": "skyblock_gui:skills/carpentry/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/carpentry/locked/up_down",
+      "id": "skyblock_gui:skills/carpentry/locked/left_down",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/combat.json
+++ b/repo/guis/skills/combat.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/unlocked/start_down",
+      "id": "skyblock_gui:skills/combat/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/unlocking/start_down",
+      "id": "skyblock_gui:skills/combat/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/locked/start_down",
+      "id": "skyblock_gui:skills/combat/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Combat Level 1",
               "Combat Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 2",
-              "Combat Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 2",
-              "Combat Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 2",
-              "Combat Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 3",
-              "Combat Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 3",
-              "Combat Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 3",
-              "Combat Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 4",
-              "Combat Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 4",
-              "Combat Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 4",
-              "Combat Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -266,16 +86,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Combat Level 5",
-              "Combat Level V"
+              "Combat Level 2",
+              "Combat Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -294,8 +111,8 @@
           },
           {
             "name": [
-              "Combat Level 5",
-              "Combat Level V"
+              "Combat Level 2",
+              "Combat Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -314,8 +131,8 @@
           },
           {
             "name": [
-              "Combat Level 5",
-              "Combat Level V"
+              "Combat Level 2",
+              "Combat Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -334,8 +151,8 @@
           },
           {
             "name": [
-              "Combat Level 6",
-              "Combat Level VI"
+              "Combat Level 3",
+              "Combat Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -354,8 +171,8 @@
           },
           {
             "name": [
-              "Combat Level 6",
-              "Combat Level VI"
+              "Combat Level 3",
+              "Combat Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -374,8 +191,8 @@
           },
           {
             "name": [
-              "Combat Level 6",
-              "Combat Level VI"
+              "Combat Level 3",
+              "Combat Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -394,8 +211,8 @@
           },
           {
             "name": [
-              "Combat Level 7",
-              "Combat Level VII"
+              "Combat Level 4",
+              "Combat Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -414,8 +231,8 @@
           },
           {
             "name": [
-              "Combat Level 7",
-              "Combat Level VII"
+              "Combat Level 4",
+              "Combat Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -434,8 +251,8 @@
           },
           {
             "name": [
-              "Combat Level 7",
-              "Combat Level VII"
+              "Combat Level 4",
+              "Combat Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -449,13 +266,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Combat Level 8",
-              "Combat Level VIII"
+              "Combat Level 5",
+              "Combat Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -474,8 +294,8 @@
           },
           {
             "name": [
-              "Combat Level 8",
-              "Combat Level VIII"
+              "Combat Level 5",
+              "Combat Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -494,8 +314,8 @@
           },
           {
             "name": [
-              "Combat Level 8",
-              "Combat Level VIII"
+              "Combat Level 5",
+              "Combat Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Combat Level 9",
-              "Combat Level IX"
+              "Combat Level 6",
+              "Combat Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,8 +354,8 @@
           },
           {
             "name": [
-              "Combat Level 9",
-              "Combat Level IX"
+              "Combat Level 6",
+              "Combat Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -554,8 +374,8 @@
           },
           {
             "name": [
-              "Combat Level 9",
-              "Combat Level IX"
+              "Combat Level 6",
+              "Combat Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -569,16 +389,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Combat Level 10",
-              "Combat Level X"
+              "Combat Level 7",
+              "Combat Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -597,8 +414,8 @@
           },
           {
             "name": [
-              "Combat Level 10",
-              "Combat Level X"
+              "Combat Level 7",
+              "Combat Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -617,8 +434,8 @@
           },
           {
             "name": [
-              "Combat Level 10",
-              "Combat Level X"
+              "Combat Level 7",
+              "Combat Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -637,8 +454,8 @@
           },
           {
             "name": [
-              "Combat Level 11",
-              "Combat Level XI"
+              "Combat Level 8",
+              "Combat Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -657,8 +474,8 @@
           },
           {
             "name": [
-              "Combat Level 11",
-              "Combat Level XI"
+              "Combat Level 8",
+              "Combat Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -677,8 +494,8 @@
           },
           {
             "name": [
-              "Combat Level 11",
-              "Combat Level XI"
+              "Combat Level 8",
+              "Combat Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -697,8 +514,8 @@
           },
           {
             "name": [
-              "Combat Level 12",
-              "Combat Level XII"
+              "Combat Level 9",
+              "Combat Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -717,8 +534,8 @@
           },
           {
             "name": [
-              "Combat Level 12",
-              "Combat Level XII"
+              "Combat Level 9",
+              "Combat Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -737,8 +554,8 @@
           },
           {
             "name": [
-              "Combat Level 12",
-              "Combat Level XII"
+              "Combat Level 9",
+              "Combat Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -752,13 +569,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Combat Level 13",
-              "Combat Level XIII"
+              "Combat Level 10",
+              "Combat Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -777,8 +597,8 @@
           },
           {
             "name": [
-              "Combat Level 13",
-              "Combat Level XIII"
+              "Combat Level 10",
+              "Combat Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -797,8 +617,8 @@
           },
           {
             "name": [
-              "Combat Level 13",
-              "Combat Level XIII"
+              "Combat Level 10",
+              "Combat Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Combat Level 14",
-              "Combat Level XIV"
+              "Combat Level 11",
+              "Combat Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,8 +657,8 @@
           },
           {
             "name": [
-              "Combat Level 14",
-              "Combat Level XIV"
+              "Combat Level 11",
+              "Combat Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -857,8 +677,8 @@
           },
           {
             "name": [
-              "Combat Level 14",
-              "Combat Level XIV"
+              "Combat Level 11",
+              "Combat Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -872,16 +692,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Combat Level 15",
-              "Combat Level XV"
+              "Combat Level 12",
+              "Combat Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -900,8 +717,8 @@
           },
           {
             "name": [
-              "Combat Level 15",
-              "Combat Level XV"
+              "Combat Level 12",
+              "Combat Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -920,8 +737,8 @@
           },
           {
             "name": [
-              "Combat Level 15",
-              "Combat Level XV"
+              "Combat Level 12",
+              "Combat Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -940,8 +757,8 @@
           },
           {
             "name": [
-              "Combat Level 16",
-              "Combat Level XVI"
+              "Combat Level 13",
+              "Combat Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -960,8 +777,8 @@
           },
           {
             "name": [
-              "Combat Level 16",
-              "Combat Level XVI"
+              "Combat Level 13",
+              "Combat Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -980,8 +797,8 @@
           },
           {
             "name": [
-              "Combat Level 16",
-              "Combat Level XVI"
+              "Combat Level 13",
+              "Combat Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1000,8 +817,8 @@
           },
           {
             "name": [
-              "Combat Level 17",
-              "Combat Level XVII"
+              "Combat Level 14",
+              "Combat Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1020,8 +837,8 @@
           },
           {
             "name": [
-              "Combat Level 17",
-              "Combat Level XVII"
+              "Combat Level 14",
+              "Combat Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1040,8 +857,8 @@
           },
           {
             "name": [
-              "Combat Level 17",
-              "Combat Level XVII"
+              "Combat Level 14",
+              "Combat Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1055,13 +872,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Combat Level 18",
-              "Combat Level XVIII"
+              "Combat Level 15",
+              "Combat Level XV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1080,6 +900,166 @@
           },
           {
             "name": [
+              "Combat Level 15",
+              "Combat Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 15",
+              "Combat Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 16",
+              "Combat Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 16",
+              "Combat Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 16",
+              "Combat Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 17",
+              "Combat Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 17",
+              "Combat Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 17",
+              "Combat Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Combat Level 18",
               "Combat Level XVIII"
             ],
@@ -1091,7 +1071,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/locked/down_right",
+      "id": "skyblock_gui:skills/combat/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 18",
+              "Combat Level XVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1111,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "id": "skyblock_gui:skills/combat/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1131,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "id": "skyblock_gui:skills/combat/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "id": "skyblock_gui:skills/combat/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/unlocked/left_down",
+      "id": "skyblock_gui:skills/combat/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -1194,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/unlocking/left_down",
+      "id": "skyblock_gui:skills/combat/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1205,6 +1205,429 @@
             "name": [
               "Combat Level 20",
               "Combat Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 20",
+              "Combat Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 21",
+              "Combat Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 21",
+              "Combat Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 21",
+              "Combat Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 22",
+              "Combat Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 22",
+              "Combat Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 22",
+              "Combat Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 23",
+              "Combat Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 23",
+              "Combat Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 23",
+              "Combat Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 24",
+              "Combat Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 24",
+              "Combat Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 24",
+              "Combat Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 25",
+              "Combat Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 25",
+              "Combat Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 25",
+              "Combat Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 26",
+              "Combat Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 26",
+              "Combat Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 26",
+              "Combat Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 27",
+              "Combat Level XXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 27",
+              "Combat Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1646,8 @@
           },
           {
             "name": [
-              "Combat Level 20",
-              "Combat Level XX"
+              "Combat Level 27",
+              "Combat Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1666,8 @@
           },
           {
             "name": [
-              "Combat Level 21",
-              "Combat Level XXI"
+              "Combat Level 28",
+              "Combat Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1686,8 @@
           },
           {
             "name": [
-              "Combat Level 21",
-              "Combat Level XXI"
+              "Combat Level 28",
+              "Combat Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1706,8 @@
           },
           {
             "name": [
-              "Combat Level 21",
-              "Combat Level XXI"
+              "Combat Level 28",
+              "Combat Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1726,8 @@
           },
           {
             "name": [
-              "Combat Level 22",
-              "Combat Level XXII"
+              "Combat Level 29",
+              "Combat Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1746,8 @@
           },
           {
             "name": [
-              "Combat Level 22",
-              "Combat Level XXII"
+              "Combat Level 29",
+              "Combat Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,8 +1766,494 @@
           },
           {
             "name": [
-              "Combat Level 22",
-              "Combat Level XXII"
+              "Combat Level 29",
+              "Combat Level XXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 30",
+              "Combat Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 30",
+              "Combat Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 30",
+              "Combat Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 31",
+              "Combat Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 31",
+              "Combat Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 31",
+              "Combat Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 32",
+              "Combat Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 32",
+              "Combat Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 32",
+              "Combat Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 33",
+              "Combat Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 33",
+              "Combat Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 33",
+              "Combat Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 34",
+              "Combat Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 34",
+              "Combat Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 34",
+              "Combat Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 35",
+              "Combat Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 35",
+              "Combat Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 35",
+              "Combat Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 36",
+              "Combat Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 36",
+              "Combat Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 36",
+              "Combat Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 37",
+              "Combat Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 37",
+              "Combat Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 37",
+              "Combat Level XXXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1363,8 +2272,8 @@
           },
           {
             "name": [
-              "Combat Level 23",
-              "Combat Level XXIII"
+              "Combat Level 38",
+              "Combat Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1383,8 +2292,8 @@
           },
           {
             "name": [
-              "Combat Level 23",
-              "Combat Level XXIII"
+              "Combat Level 38",
+              "Combat Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1403,8 +2312,8 @@
           },
           {
             "name": [
-              "Combat Level 23",
-              "Combat Level XXIII"
+              "Combat Level 38",
+              "Combat Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1423,8 +2332,8 @@
           },
           {
             "name": [
-              "Combat Level 24",
-              "Combat Level XXIV"
+              "Combat Level 39",
+              "Combat Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1443,8 +2352,8 @@
           },
           {
             "name": [
-              "Combat Level 24",
-              "Combat Level XXIV"
+              "Combat Level 39",
+              "Combat Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1463,8 +2372,1220 @@
           },
           {
             "name": [
-              "Combat Level 24",
-              "Combat Level XXIV"
+              "Combat Level 39",
+              "Combat Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 40",
+              "Combat Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 40",
+              "Combat Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 40",
+              "Combat Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 41",
+              "Combat Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 41",
+              "Combat Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 41",
+              "Combat Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 42",
+              "Combat Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 42",
+              "Combat Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 42",
+              "Combat Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 43",
+              "Combat Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 43",
+              "Combat Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 43",
+              "Combat Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 44",
+              "Combat Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 44",
+              "Combat Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 44",
+              "Combat Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 45",
+              "Combat Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 45",
+              "Combat Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 45",
+              "Combat Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 46",
+              "Combat Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 46",
+              "Combat Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 46",
+              "Combat Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 47",
+              "Combat Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 47",
+              "Combat Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 47",
+              "Combat Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 48",
+              "Combat Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 48",
+              "Combat Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 48",
+              "Combat Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 49",
+              "Combat Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 49",
+              "Combat Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 49",
+              "Combat Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 50",
+              "Combat Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 50",
+              "Combat Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 50",
+              "Combat Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 51",
+              "Combat Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 51",
+              "Combat Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 51",
+              "Combat Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 52",
+              "Combat Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 52",
+              "Combat Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 52",
+              "Combat Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 53",
+              "Combat Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 53",
+              "Combat Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 53",
+              "Combat Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 54",
+              "Combat Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 54",
+              "Combat Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 54",
+              "Combat Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:diamond_helmet"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 55",
+              "Combat Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 55",
+              "Combat Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 55",
+              "Combat Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 56",
+              "Combat Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 56",
+              "Combat Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 56",
+              "Combat Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 57",
+              "Combat Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 57",
+              "Combat Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 57",
+              "Combat Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 58",
+              "Combat Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 58",
+              "Combat Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 58",
+              "Combat Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 59",
+              "Combat Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 59",
+              "Combat Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/combat/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Combat Level 59",
+              "Combat Level LIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1475,2127 +3596,6 @@
     },
     {
       "id": "skyblock_gui:skills/combat/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 25",
-              "Combat Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 25",
-              "Combat Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 25",
-              "Combat Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 26",
-              "Combat Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 26",
-              "Combat Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 26",
-              "Combat Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 27",
-              "Combat Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 27",
-              "Combat Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 27",
-              "Combat Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 28",
-              "Combat Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 28",
-              "Combat Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 28",
-              "Combat Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 29",
-              "Combat Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 29",
-              "Combat Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 29",
-              "Combat Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 30",
-              "Combat Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 30",
-              "Combat Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 30",
-              "Combat Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 31",
-              "Combat Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 31",
-              "Combat Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 31",
-              "Combat Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 32",
-              "Combat Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 32",
-              "Combat Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 32",
-              "Combat Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 33",
-              "Combat Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 33",
-              "Combat Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 33",
-              "Combat Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 34",
-              "Combat Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 34",
-              "Combat Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 34",
-              "Combat Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 35",
-              "Combat Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 35",
-              "Combat Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 35",
-              "Combat Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 36",
-              "Combat Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 36",
-              "Combat Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 36",
-              "Combat Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 37",
-              "Combat Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 37",
-              "Combat Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 37",
-              "Combat Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 38",
-              "Combat Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 38",
-              "Combat Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 38",
-              "Combat Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 39",
-              "Combat Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 39",
-              "Combat Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 39",
-              "Combat Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 40",
-              "Combat Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 40",
-              "Combat Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 40",
-              "Combat Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 41",
-              "Combat Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 41",
-              "Combat Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 41",
-              "Combat Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 42",
-              "Combat Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 42",
-              "Combat Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 42",
-              "Combat Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 43",
-              "Combat Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 43",
-              "Combat Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 43",
-              "Combat Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 44",
-              "Combat Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 44",
-              "Combat Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 44",
-              "Combat Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 45",
-              "Combat Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 45",
-              "Combat Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 45",
-              "Combat Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 46",
-              "Combat Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 46",
-              "Combat Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 46",
-              "Combat Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 47",
-              "Combat Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 47",
-              "Combat Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 47",
-              "Combat Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 48",
-              "Combat Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 48",
-              "Combat Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 48",
-              "Combat Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 49",
-              "Combat Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 49",
-              "Combat Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 49",
-              "Combat Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 50",
-              "Combat Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 50",
-              "Combat Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 50",
-              "Combat Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 51",
-              "Combat Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 51",
-              "Combat Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 51",
-              "Combat Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 52",
-              "Combat Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 52",
-              "Combat Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 52",
-              "Combat Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 53",
-              "Combat Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 53",
-              "Combat Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 53",
-              "Combat Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 54",
-              "Combat Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 54",
-              "Combat Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 54",
-              "Combat Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:diamond_helmet"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 55",
-              "Combat Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 55",
-              "Combat Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 55",
-              "Combat Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 56",
-              "Combat Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 56",
-              "Combat Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 56",
-              "Combat Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 57",
-              "Combat Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 57",
-              "Combat Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 57",
-              "Combat Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 58",
-              "Combat Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 58",
-              "Combat Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 58",
-              "Combat Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 59",
-              "Combat Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 59",
-              "Combat Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Combat Level 59",
-              "Combat Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/combat/unlocked/left_end",
       "target": {
         "conditions": [
           {
@@ -3618,7 +3618,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/unlocking/left_end",
+      "id": "skyblock_gui:skills/combat/unlocking/up_end",
       "target": {
         "conditions": [
           {
@@ -3638,7 +3638,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/combat/locked/left_end",
+      "id": "skyblock_gui:skills/combat/locked/up_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/dungeoneering/catacombs/catacombs.json
+++ b/repo/guis/skills/dungeoneering/catacombs/catacombs.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/start_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/start_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/start_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Catacombs Mastery 1",
               "Catacombs Mastery I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 2",
-              "Catacombs Mastery II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 2",
-              "Catacombs Mastery II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 2",
-              "Catacombs Mastery II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 3",
-              "Catacombs Mastery III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 3",
-              "Catacombs Mastery III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 3",
-              "Catacombs Mastery III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 4",
-              "Catacombs Mastery IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 4",
-              "Catacombs Mastery IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 4",
-              "Catacombs Mastery IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 2",
+              "Catacombs Mastery II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 2",
+              "Catacombs Mastery II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 2",
+              "Catacombs Mastery II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 3",
+              "Catacombs Mastery III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 3",
+              "Catacombs Mastery III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 3",
+              "Catacombs Mastery III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 4",
+              "Catacombs Mastery IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 4",
+              "Catacombs Mastery IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 4",
+              "Catacombs Mastery IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_up",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_up",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 6",
-              "Catacombs Mastery VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 6",
-              "Catacombs Mastery VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 6",
-              "Catacombs Mastery VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 7",
-              "Catacombs Mastery VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 7",
-              "Catacombs Mastery VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 7",
-              "Catacombs Mastery VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 8",
-              "Catacombs Mastery VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 8",
-              "Catacombs Mastery VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 8",
-              "Catacombs Mastery VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 9",
-              "Catacombs Mastery IX"
+              "Catacombs Mastery 6",
+              "Catacombs Mastery VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Catacombs Mastery 6",
+              "Catacombs Mastery VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 6",
+              "Catacombs Mastery VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 7",
+              "Catacombs Mastery VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 7",
+              "Catacombs Mastery VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 7",
+              "Catacombs Mastery VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 8",
+              "Catacombs Mastery VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 8",
+              "Catacombs Mastery VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 8",
+              "Catacombs Mastery VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Catacombs Mastery 9",
               "Catacombs Mastery IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 9",
+              "Catacombs Mastery IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 11",
-              "Catacombs Mastery XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 11",
-              "Catacombs Mastery XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 11",
-              "Catacombs Mastery XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 12",
-              "Catacombs Mastery XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 12",
-              "Catacombs Mastery XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 12",
-              "Catacombs Mastery XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 13",
-              "Catacombs Mastery XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 13",
-              "Catacombs Mastery XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 13",
-              "Catacombs Mastery XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 14",
-              "Catacombs Mastery XIV"
+              "Catacombs Mastery 11",
+              "Catacombs Mastery XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Catacombs Mastery 11",
+              "Catacombs Mastery XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 11",
+              "Catacombs Mastery XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 12",
+              "Catacombs Mastery XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 12",
+              "Catacombs Mastery XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 12",
+              "Catacombs Mastery XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 13",
+              "Catacombs Mastery XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 13",
+              "Catacombs Mastery XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 13",
+              "Catacombs Mastery XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Catacombs Mastery 14",
               "Catacombs Mastery XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 14",
+              "Catacombs Mastery XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_up",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_up",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_up",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 16",
-              "Catacombs Mastery XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 16",
-              "Catacombs Mastery XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 16",
-              "Catacombs Mastery XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 17",
-              "Catacombs Mastery XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 17",
-              "Catacombs Mastery XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 17",
-              "Catacombs Mastery XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 18",
-              "Catacombs Mastery XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 18",
-              "Catacombs Mastery XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 18",
-              "Catacombs Mastery XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 19",
-              "Catacombs Mastery XIX"
+              "Catacombs Mastery 16",
+              "Catacombs Mastery XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 19",
-              "Catacombs Mastery XIX"
+              "Catacombs Mastery 16",
+              "Catacombs Mastery XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 19",
-              "Catacombs Mastery XIX"
+              "Catacombs Mastery 16",
+              "Catacombs Mastery XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:player_head"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 20",
-              "Catacombs Mastery XX"
+              "Catacombs Mastery 17",
+              "Catacombs Mastery XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 20",
-              "Catacombs Mastery XX"
+              "Catacombs Mastery 17",
+              "Catacombs Mastery XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 20",
-              "Catacombs Mastery XX"
+              "Catacombs Mastery 17",
+              "Catacombs Mastery XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 21",
-              "Catacombs Mastery XXI"
+              "Catacombs Mastery 18",
+              "Catacombs Mastery XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 21",
-              "Catacombs Mastery XXI"
+              "Catacombs Mastery 18",
+              "Catacombs Mastery XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 21",
-              "Catacombs Mastery XXI"
+              "Catacombs Mastery 18",
+              "Catacombs Mastery XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 22",
-              "Catacombs Mastery XXII"
+              "Catacombs Mastery 19",
+              "Catacombs Mastery XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 22",
-              "Catacombs Mastery XXII"
+              "Catacombs Mastery 19",
+              "Catacombs Mastery XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 22",
-              "Catacombs Mastery XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 23",
-              "Catacombs Mastery XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 23",
-              "Catacombs Mastery XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 23",
-              "Catacombs Mastery XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 24",
-              "Catacombs Mastery XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 24",
-              "Catacombs Mastery XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 24",
-              "Catacombs Mastery XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:player_head"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 25",
-              "Catacombs Mastery XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 25",
-              "Catacombs Mastery XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 25",
-              "Catacombs Mastery XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 26",
-              "Catacombs Mastery XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 26",
-              "Catacombs Mastery XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 26",
-              "Catacombs Mastery XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 27",
-              "Catacombs Mastery XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 27",
-              "Catacombs Mastery XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Catacombs Mastery 27",
-              "Catacombs Mastery XXVII"
+              "Catacombs Mastery 19",
+              "Catacombs Mastery XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:player_head"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 28",
-              "Catacombs Mastery XXVIII"
+              "Catacombs Mastery 20",
+              "Catacombs Mastery XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 28",
-              "Catacombs Mastery XXVIII"
+              "Catacombs Mastery 20",
+              "Catacombs Mastery XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 28",
-              "Catacombs Mastery XXVIII"
+              "Catacombs Mastery 20",
+              "Catacombs Mastery XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 29",
-              "Catacombs Mastery XXIX"
+              "Catacombs Mastery 21",
+              "Catacombs Mastery XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 29",
-              "Catacombs Mastery XXIX"
+              "Catacombs Mastery 21",
+              "Catacombs Mastery XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 29",
-              "Catacombs Mastery XXIX"
+              "Catacombs Mastery 21",
+              "Catacombs Mastery XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:player_head"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 30",
-              "Catacombs Mastery XXX"
+              "Catacombs Mastery 22",
+              "Catacombs Mastery XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 30",
-              "Catacombs Mastery XXX"
+              "Catacombs Mastery 22",
+              "Catacombs Mastery XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 30",
-              "Catacombs Mastery XXX"
+              "Catacombs Mastery 22",
+              "Catacombs Mastery XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 31",
-              "Catacombs Mastery XXXI"
+              "Catacombs Mastery 23",
+              "Catacombs Mastery XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 31",
-              "Catacombs Mastery XXXI"
+              "Catacombs Mastery 23",
+              "Catacombs Mastery XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 31",
-              "Catacombs Mastery XXXI"
+              "Catacombs Mastery 23",
+              "Catacombs Mastery XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 32",
-              "Catacombs Mastery XXXII"
+              "Catacombs Mastery 24",
+              "Catacombs Mastery XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 32",
-              "Catacombs Mastery XXXII"
+              "Catacombs Mastery 24",
+              "Catacombs Mastery XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 32",
-              "Catacombs Mastery XXXII"
+              "Catacombs Mastery 24",
+              "Catacombs Mastery XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:player_head"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 33",
-              "Catacombs Mastery XXXIII"
+              "Catacombs Mastery 25",
+              "Catacombs Mastery XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 33",
-              "Catacombs Mastery XXXIII"
+              "Catacombs Mastery 25",
+              "Catacombs Mastery XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 33",
-              "Catacombs Mastery XXXIII"
+              "Catacombs Mastery 25",
+              "Catacombs Mastery XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 34",
-              "Catacombs Mastery XXXIV"
+              "Catacombs Mastery 26",
+              "Catacombs Mastery XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 34",
-              "Catacombs Mastery XXXIV"
+              "Catacombs Mastery 26",
+              "Catacombs Mastery XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 34",
-              "Catacombs Mastery XXXIV"
+              "Catacombs Mastery 26",
+              "Catacombs Mastery XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:player_head"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 35",
-              "Catacombs Mastery XXXV"
+              "Catacombs Mastery 27",
+              "Catacombs Mastery XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 35",
-              "Catacombs Mastery XXXV"
+              "Catacombs Mastery 27",
+              "Catacombs Mastery XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 35",
-              "Catacombs Mastery XXXV"
+              "Catacombs Mastery 27",
+              "Catacombs Mastery XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 36",
-              "Catacombs Mastery XXXVI"
+              "Catacombs Mastery 28",
+              "Catacombs Mastery XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 36",
-              "Catacombs Mastery XXXVI"
+              "Catacombs Mastery 28",
+              "Catacombs Mastery XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 36",
-              "Catacombs Mastery XXXVI"
+              "Catacombs Mastery 28",
+              "Catacombs Mastery XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 37",
-              "Catacombs Mastery XXXVII"
+              "Catacombs Mastery 29",
+              "Catacombs Mastery XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 37",
-              "Catacombs Mastery XXXVII"
+              "Catacombs Mastery 29",
+              "Catacombs Mastery XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 37",
-              "Catacombs Mastery XXXVII"
+              "Catacombs Mastery 29",
+              "Catacombs Mastery XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:player_head"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 38",
-              "Catacombs Mastery XXXVIII"
+              "Catacombs Mastery 30",
+              "Catacombs Mastery XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 38",
-              "Catacombs Mastery XXXVIII"
+              "Catacombs Mastery 30",
+              "Catacombs Mastery XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 38",
-              "Catacombs Mastery XXXVIII"
+              "Catacombs Mastery 30",
+              "Catacombs Mastery XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 39",
-              "Catacombs Mastery XXXIX"
+              "Catacombs Mastery 31",
+              "Catacombs Mastery XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 39",
-              "Catacombs Mastery XXXIX"
+              "Catacombs Mastery 31",
+              "Catacombs Mastery XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 39",
-              "Catacombs Mastery XXXIX"
+              "Catacombs Mastery 31",
+              "Catacombs Mastery XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:player_head"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 40",
-              "Catacombs Mastery XL"
+              "Catacombs Mastery 32",
+              "Catacombs Mastery XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 40",
-              "Catacombs Mastery XL"
+              "Catacombs Mastery 32",
+              "Catacombs Mastery XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 40",
-              "Catacombs Mastery XL"
+              "Catacombs Mastery 32",
+              "Catacombs Mastery XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 41",
-              "Catacombs Mastery XLI"
+              "Catacombs Mastery 33",
+              "Catacombs Mastery XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 41",
-              "Catacombs Mastery XLI"
+              "Catacombs Mastery 33",
+              "Catacombs Mastery XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 41",
-              "Catacombs Mastery XLI"
+              "Catacombs Mastery 33",
+              "Catacombs Mastery XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 42",
-              "Catacombs Mastery XLII"
+              "Catacombs Mastery 34",
+              "Catacombs Mastery XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 42",
-              "Catacombs Mastery XLII"
+              "Catacombs Mastery 34",
+              "Catacombs Mastery XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Catacombs Mastery 42",
-              "Catacombs Mastery XLII"
+              "Catacombs Mastery 34",
+              "Catacombs Mastery XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:player_head"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Catacombs Mastery 43",
-              "Catacombs Mastery XLIII"
+              "Catacombs Mastery 35",
+              "Catacombs Mastery XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Catacombs Mastery 35",
+              "Catacombs Mastery XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 35",
+              "Catacombs Mastery XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 36",
+              "Catacombs Mastery XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 36",
+              "Catacombs Mastery XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 36",
+              "Catacombs Mastery XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 37",
+              "Catacombs Mastery XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 37",
+              "Catacombs Mastery XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 37",
+              "Catacombs Mastery XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 38",
+              "Catacombs Mastery XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 38",
+              "Catacombs Mastery XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 38",
+              "Catacombs Mastery XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 39",
+              "Catacombs Mastery XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 39",
+              "Catacombs Mastery XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 39",
+              "Catacombs Mastery XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:player_head"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 40",
+              "Catacombs Mastery XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 40",
+              "Catacombs Mastery XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 40",
+              "Catacombs Mastery XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 41",
+              "Catacombs Mastery XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 41",
+              "Catacombs Mastery XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 41",
+              "Catacombs Mastery XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 42",
+              "Catacombs Mastery XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 42",
+              "Catacombs Mastery XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 42",
+              "Catacombs Mastery XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Catacombs Mastery 43",
               "Catacombs Mastery XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_right",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Catacombs Mastery 43",
+              "Catacombs Mastery XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_right",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/up_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/up_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/up_down",
+      "id": "skyblock_gui:skills/dungeoneering/catacombs/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -3056,7 +3056,7 @@
       "target": {
         "conditions": [
           {
-            "slot": 45,
+            "slot": 41,
             "type": "catharsis:slot"
           },
           {
@@ -3077,7 +3077,7 @@
       "target": {
         "conditions": [
           {
-            "slot": 40,
+            "slot": 39,
             "type": "catharsis:slot"
           },
           {

--- a/repo/guis/skills/enchanting.json
+++ b/repo/guis/skills/enchanting.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/unlocked/start_down",
+      "id": "skyblock_gui:skills/enchanting/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/unlocking/start_down",
+      "id": "skyblock_gui:skills/enchanting/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/locked/start_down",
+      "id": "skyblock_gui:skills/enchanting/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Enchanting Level 1",
               "Enchanting Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 2",
-              "Enchanting Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 2",
-              "Enchanting Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 2",
-              "Enchanting Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 3",
-              "Enchanting Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 3",
-              "Enchanting Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 3",
-              "Enchanting Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 4",
-              "Enchanting Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 4",
-              "Enchanting Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 4",
-              "Enchanting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -266,16 +86,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Enchanting Level 5",
-              "Enchanting Level V"
+              "Enchanting Level 2",
+              "Enchanting Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -294,8 +111,8 @@
           },
           {
             "name": [
-              "Enchanting Level 5",
-              "Enchanting Level V"
+              "Enchanting Level 2",
+              "Enchanting Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -314,8 +131,8 @@
           },
           {
             "name": [
-              "Enchanting Level 5",
-              "Enchanting Level V"
+              "Enchanting Level 2",
+              "Enchanting Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -334,8 +151,8 @@
           },
           {
             "name": [
-              "Enchanting Level 6",
-              "Enchanting Level VI"
+              "Enchanting Level 3",
+              "Enchanting Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -354,8 +171,8 @@
           },
           {
             "name": [
-              "Enchanting Level 6",
-              "Enchanting Level VI"
+              "Enchanting Level 3",
+              "Enchanting Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -374,8 +191,8 @@
           },
           {
             "name": [
-              "Enchanting Level 6",
-              "Enchanting Level VI"
+              "Enchanting Level 3",
+              "Enchanting Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -394,8 +211,8 @@
           },
           {
             "name": [
-              "Enchanting Level 7",
-              "Enchanting Level VII"
+              "Enchanting Level 4",
+              "Enchanting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -414,8 +231,8 @@
           },
           {
             "name": [
-              "Enchanting Level 7",
-              "Enchanting Level VII"
+              "Enchanting Level 4",
+              "Enchanting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -434,8 +251,8 @@
           },
           {
             "name": [
-              "Enchanting Level 7",
-              "Enchanting Level VII"
+              "Enchanting Level 4",
+              "Enchanting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -449,13 +266,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Enchanting Level 8",
-              "Enchanting Level VIII"
+              "Enchanting Level 5",
+              "Enchanting Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -474,8 +294,8 @@
           },
           {
             "name": [
-              "Enchanting Level 8",
-              "Enchanting Level VIII"
+              "Enchanting Level 5",
+              "Enchanting Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -494,8 +314,8 @@
           },
           {
             "name": [
-              "Enchanting Level 8",
-              "Enchanting Level VIII"
+              "Enchanting Level 5",
+              "Enchanting Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Enchanting Level 9",
-              "Enchanting Level IX"
+              "Enchanting Level 6",
+              "Enchanting Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,8 +354,8 @@
           },
           {
             "name": [
-              "Enchanting Level 9",
-              "Enchanting Level IX"
+              "Enchanting Level 6",
+              "Enchanting Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -554,8 +374,8 @@
           },
           {
             "name": [
-              "Enchanting Level 9",
-              "Enchanting Level IX"
+              "Enchanting Level 6",
+              "Enchanting Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -569,16 +389,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Enchanting Level 10",
-              "Enchanting Level X"
+              "Enchanting Level 7",
+              "Enchanting Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -597,8 +414,8 @@
           },
           {
             "name": [
-              "Enchanting Level 10",
-              "Enchanting Level X"
+              "Enchanting Level 7",
+              "Enchanting Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -617,8 +434,8 @@
           },
           {
             "name": [
-              "Enchanting Level 10",
-              "Enchanting Level X"
+              "Enchanting Level 7",
+              "Enchanting Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -637,8 +454,8 @@
           },
           {
             "name": [
-              "Enchanting Level 11",
-              "Enchanting Level XI"
+              "Enchanting Level 8",
+              "Enchanting Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -657,8 +474,8 @@
           },
           {
             "name": [
-              "Enchanting Level 11",
-              "Enchanting Level XI"
+              "Enchanting Level 8",
+              "Enchanting Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -677,8 +494,8 @@
           },
           {
             "name": [
-              "Enchanting Level 11",
-              "Enchanting Level XI"
+              "Enchanting Level 8",
+              "Enchanting Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -697,8 +514,8 @@
           },
           {
             "name": [
-              "Enchanting Level 12",
-              "Enchanting Level XII"
+              "Enchanting Level 9",
+              "Enchanting Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -717,8 +534,8 @@
           },
           {
             "name": [
-              "Enchanting Level 12",
-              "Enchanting Level XII"
+              "Enchanting Level 9",
+              "Enchanting Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -737,8 +554,8 @@
           },
           {
             "name": [
-              "Enchanting Level 12",
-              "Enchanting Level XII"
+              "Enchanting Level 9",
+              "Enchanting Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -752,13 +569,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Enchanting Level 13",
-              "Enchanting Level XIII"
+              "Enchanting Level 10",
+              "Enchanting Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -777,8 +597,8 @@
           },
           {
             "name": [
-              "Enchanting Level 13",
-              "Enchanting Level XIII"
+              "Enchanting Level 10",
+              "Enchanting Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -797,8 +617,8 @@
           },
           {
             "name": [
-              "Enchanting Level 13",
-              "Enchanting Level XIII"
+              "Enchanting Level 10",
+              "Enchanting Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Enchanting Level 14",
-              "Enchanting Level XIV"
+              "Enchanting Level 11",
+              "Enchanting Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,8 +657,8 @@
           },
           {
             "name": [
-              "Enchanting Level 14",
-              "Enchanting Level XIV"
+              "Enchanting Level 11",
+              "Enchanting Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -857,8 +677,8 @@
           },
           {
             "name": [
-              "Enchanting Level 14",
-              "Enchanting Level XIV"
+              "Enchanting Level 11",
+              "Enchanting Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -872,16 +692,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Enchanting Level 15",
-              "Enchanting Level XV"
+              "Enchanting Level 12",
+              "Enchanting Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -900,8 +717,8 @@
           },
           {
             "name": [
-              "Enchanting Level 15",
-              "Enchanting Level XV"
+              "Enchanting Level 12",
+              "Enchanting Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -920,8 +737,8 @@
           },
           {
             "name": [
-              "Enchanting Level 15",
-              "Enchanting Level XV"
+              "Enchanting Level 12",
+              "Enchanting Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -940,8 +757,8 @@
           },
           {
             "name": [
-              "Enchanting Level 16",
-              "Enchanting Level XVI"
+              "Enchanting Level 13",
+              "Enchanting Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -960,8 +777,8 @@
           },
           {
             "name": [
-              "Enchanting Level 16",
-              "Enchanting Level XVI"
+              "Enchanting Level 13",
+              "Enchanting Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -980,8 +797,8 @@
           },
           {
             "name": [
-              "Enchanting Level 16",
-              "Enchanting Level XVI"
+              "Enchanting Level 13",
+              "Enchanting Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1000,8 +817,8 @@
           },
           {
             "name": [
-              "Enchanting Level 17",
-              "Enchanting Level XVII"
+              "Enchanting Level 14",
+              "Enchanting Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1020,8 +837,8 @@
           },
           {
             "name": [
-              "Enchanting Level 17",
-              "Enchanting Level XVII"
+              "Enchanting Level 14",
+              "Enchanting Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1040,8 +857,8 @@
           },
           {
             "name": [
-              "Enchanting Level 17",
-              "Enchanting Level XVII"
+              "Enchanting Level 14",
+              "Enchanting Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1055,13 +872,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Enchanting Level 18",
-              "Enchanting Level XVIII"
+              "Enchanting Level 15",
+              "Enchanting Level XV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1080,6 +900,166 @@
           },
           {
             "name": [
+              "Enchanting Level 15",
+              "Enchanting Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 15",
+              "Enchanting Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 16",
+              "Enchanting Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 16",
+              "Enchanting Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 16",
+              "Enchanting Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 17",
+              "Enchanting Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 17",
+              "Enchanting Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 17",
+              "Enchanting Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Enchanting Level 18",
               "Enchanting Level XVIII"
             ],
@@ -1091,7 +1071,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/locked/down_right",
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 18",
+              "Enchanting Level XVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1111,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1131,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "id": "skyblock_gui:skills/enchanting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -1194,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1205,6 +1205,429 @@
             "name": [
               "Enchanting Level 20",
               "Enchanting Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 20",
+              "Enchanting Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 21",
+              "Enchanting Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 21",
+              "Enchanting Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 21",
+              "Enchanting Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 22",
+              "Enchanting Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 22",
+              "Enchanting Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 22",
+              "Enchanting Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 23",
+              "Enchanting Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 23",
+              "Enchanting Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 23",
+              "Enchanting Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 24",
+              "Enchanting Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 24",
+              "Enchanting Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 24",
+              "Enchanting Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 25",
+              "Enchanting Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 25",
+              "Enchanting Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 25",
+              "Enchanting Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 26",
+              "Enchanting Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 26",
+              "Enchanting Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 26",
+              "Enchanting Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 27",
+              "Enchanting Level XXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 27",
+              "Enchanting Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1646,8 @@
           },
           {
             "name": [
-              "Enchanting Level 20",
-              "Enchanting Level XX"
+              "Enchanting Level 27",
+              "Enchanting Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1666,8 @@
           },
           {
             "name": [
-              "Enchanting Level 21",
-              "Enchanting Level XXI"
+              "Enchanting Level 28",
+              "Enchanting Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1686,8 @@
           },
           {
             "name": [
-              "Enchanting Level 21",
-              "Enchanting Level XXI"
+              "Enchanting Level 28",
+              "Enchanting Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1706,8 @@
           },
           {
             "name": [
-              "Enchanting Level 21",
-              "Enchanting Level XXI"
+              "Enchanting Level 28",
+              "Enchanting Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1726,8 @@
           },
           {
             "name": [
-              "Enchanting Level 22",
-              "Enchanting Level XXII"
+              "Enchanting Level 29",
+              "Enchanting Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1746,8 @@
           },
           {
             "name": [
-              "Enchanting Level 22",
-              "Enchanting Level XXII"
+              "Enchanting Level 29",
+              "Enchanting Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,8 +1766,494 @@
           },
           {
             "name": [
-              "Enchanting Level 22",
-              "Enchanting Level XXII"
+              "Enchanting Level 29",
+              "Enchanting Level XXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 30",
+              "Enchanting Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 30",
+              "Enchanting Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 30",
+              "Enchanting Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 31",
+              "Enchanting Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 31",
+              "Enchanting Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 31",
+              "Enchanting Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 32",
+              "Enchanting Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 32",
+              "Enchanting Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 32",
+              "Enchanting Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 33",
+              "Enchanting Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 33",
+              "Enchanting Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 33",
+              "Enchanting Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 34",
+              "Enchanting Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 34",
+              "Enchanting Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 34",
+              "Enchanting Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 35",
+              "Enchanting Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 35",
+              "Enchanting Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 35",
+              "Enchanting Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 36",
+              "Enchanting Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 36",
+              "Enchanting Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 36",
+              "Enchanting Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 37",
+              "Enchanting Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 37",
+              "Enchanting Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 37",
+              "Enchanting Level XXXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1363,8 +2272,8 @@
           },
           {
             "name": [
-              "Enchanting Level 23",
-              "Enchanting Level XXIII"
+              "Enchanting Level 38",
+              "Enchanting Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1383,8 +2292,8 @@
           },
           {
             "name": [
-              "Enchanting Level 23",
-              "Enchanting Level XXIII"
+              "Enchanting Level 38",
+              "Enchanting Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1403,8 +2312,8 @@
           },
           {
             "name": [
-              "Enchanting Level 23",
-              "Enchanting Level XXIII"
+              "Enchanting Level 38",
+              "Enchanting Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1423,8 +2332,8 @@
           },
           {
             "name": [
-              "Enchanting Level 24",
-              "Enchanting Level XXIV"
+              "Enchanting Level 39",
+              "Enchanting Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1443,8 +2352,8 @@
           },
           {
             "name": [
-              "Enchanting Level 24",
-              "Enchanting Level XXIV"
+              "Enchanting Level 39",
+              "Enchanting Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1463,8 +2372,1220 @@
           },
           {
             "name": [
-              "Enchanting Level 24",
-              "Enchanting Level XXIV"
+              "Enchanting Level 39",
+              "Enchanting Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 40",
+              "Enchanting Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 40",
+              "Enchanting Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 40",
+              "Enchanting Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 41",
+              "Enchanting Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 41",
+              "Enchanting Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 41",
+              "Enchanting Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 42",
+              "Enchanting Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 42",
+              "Enchanting Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 42",
+              "Enchanting Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 43",
+              "Enchanting Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 43",
+              "Enchanting Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 43",
+              "Enchanting Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 44",
+              "Enchanting Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 44",
+              "Enchanting Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 44",
+              "Enchanting Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 45",
+              "Enchanting Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 45",
+              "Enchanting Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 45",
+              "Enchanting Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 46",
+              "Enchanting Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 46",
+              "Enchanting Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 46",
+              "Enchanting Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 47",
+              "Enchanting Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 47",
+              "Enchanting Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 47",
+              "Enchanting Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 48",
+              "Enchanting Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 48",
+              "Enchanting Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 48",
+              "Enchanting Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 49",
+              "Enchanting Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 49",
+              "Enchanting Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 49",
+              "Enchanting Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 50",
+              "Enchanting Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 50",
+              "Enchanting Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 50",
+              "Enchanting Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 51",
+              "Enchanting Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 51",
+              "Enchanting Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 51",
+              "Enchanting Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 52",
+              "Enchanting Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 52",
+              "Enchanting Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 52",
+              "Enchanting Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 53",
+              "Enchanting Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 53",
+              "Enchanting Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 53",
+              "Enchanting Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 54",
+              "Enchanting Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 54",
+              "Enchanting Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 54",
+              "Enchanting Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:enchanted_book"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 55",
+              "Enchanting Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 55",
+              "Enchanting Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 55",
+              "Enchanting Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 56",
+              "Enchanting Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 56",
+              "Enchanting Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 56",
+              "Enchanting Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 57",
+              "Enchanting Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 57",
+              "Enchanting Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 57",
+              "Enchanting Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 58",
+              "Enchanting Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 58",
+              "Enchanting Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 58",
+              "Enchanting Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 59",
+              "Enchanting Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 59",
+              "Enchanting Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/enchanting/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Enchanting Level 59",
+              "Enchanting Level LIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1475,2127 +3596,6 @@
     },
     {
       "id": "skyblock_gui:skills/enchanting/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 25",
-              "Enchanting Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 25",
-              "Enchanting Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 25",
-              "Enchanting Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 26",
-              "Enchanting Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 26",
-              "Enchanting Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 26",
-              "Enchanting Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 27",
-              "Enchanting Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 27",
-              "Enchanting Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 27",
-              "Enchanting Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 28",
-              "Enchanting Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 28",
-              "Enchanting Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 28",
-              "Enchanting Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 29",
-              "Enchanting Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 29",
-              "Enchanting Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 29",
-              "Enchanting Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 30",
-              "Enchanting Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 30",
-              "Enchanting Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 30",
-              "Enchanting Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 31",
-              "Enchanting Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 31",
-              "Enchanting Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 31",
-              "Enchanting Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 32",
-              "Enchanting Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 32",
-              "Enchanting Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 32",
-              "Enchanting Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 33",
-              "Enchanting Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 33",
-              "Enchanting Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 33",
-              "Enchanting Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 34",
-              "Enchanting Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 34",
-              "Enchanting Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 34",
-              "Enchanting Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 35",
-              "Enchanting Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 35",
-              "Enchanting Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 35",
-              "Enchanting Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 36",
-              "Enchanting Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 36",
-              "Enchanting Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 36",
-              "Enchanting Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 37",
-              "Enchanting Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 37",
-              "Enchanting Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 37",
-              "Enchanting Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 38",
-              "Enchanting Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 38",
-              "Enchanting Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 38",
-              "Enchanting Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 39",
-              "Enchanting Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 39",
-              "Enchanting Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 39",
-              "Enchanting Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 40",
-              "Enchanting Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 40",
-              "Enchanting Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 40",
-              "Enchanting Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 41",
-              "Enchanting Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 41",
-              "Enchanting Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 41",
-              "Enchanting Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 42",
-              "Enchanting Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 42",
-              "Enchanting Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 42",
-              "Enchanting Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 43",
-              "Enchanting Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 43",
-              "Enchanting Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 43",
-              "Enchanting Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 44",
-              "Enchanting Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 44",
-              "Enchanting Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 44",
-              "Enchanting Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 45",
-              "Enchanting Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 45",
-              "Enchanting Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 45",
-              "Enchanting Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 46",
-              "Enchanting Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 46",
-              "Enchanting Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 46",
-              "Enchanting Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 47",
-              "Enchanting Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 47",
-              "Enchanting Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 47",
-              "Enchanting Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 48",
-              "Enchanting Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 48",
-              "Enchanting Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 48",
-              "Enchanting Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 49",
-              "Enchanting Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 49",
-              "Enchanting Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 49",
-              "Enchanting Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 50",
-              "Enchanting Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 50",
-              "Enchanting Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 50",
-              "Enchanting Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 51",
-              "Enchanting Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 51",
-              "Enchanting Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 51",
-              "Enchanting Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 52",
-              "Enchanting Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 52",
-              "Enchanting Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 52",
-              "Enchanting Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 53",
-              "Enchanting Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 53",
-              "Enchanting Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 53",
-              "Enchanting Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 54",
-              "Enchanting Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 54",
-              "Enchanting Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 54",
-              "Enchanting Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:enchanted_book"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 55",
-              "Enchanting Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 55",
-              "Enchanting Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 55",
-              "Enchanting Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 56",
-              "Enchanting Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 56",
-              "Enchanting Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 56",
-              "Enchanting Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 57",
-              "Enchanting Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 57",
-              "Enchanting Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 57",
-              "Enchanting Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 58",
-              "Enchanting Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 58",
-              "Enchanting Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 58",
-              "Enchanting Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 59",
-              "Enchanting Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 59",
-              "Enchanting Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Enchanting Level 59",
-              "Enchanting Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/enchanting/unlocked/left_end",
       "target": {
         "conditions": [
           {
@@ -3618,7 +3618,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/unlocking/left_end",
+      "id": "skyblock_gui:skills/enchanting/unlocking/up_end",
       "target": {
         "conditions": [
           {
@@ -3638,7 +3638,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/enchanting/locked/left_end",
+      "id": "skyblock_gui:skills/enchanting/locked/up_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/farming.json
+++ b/repo/guis/skills/farming.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/unlocked/start_down",
+      "id": "skyblock_gui:skills/farming/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/unlocking/start_down",
+      "id": "skyblock_gui:skills/farming/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/locked/start_down",
+      "id": "skyblock_gui:skills/farming/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Farming Level 1",
               "Farming Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 2",
-              "Farming Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 2",
-              "Farming Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 2",
-              "Farming Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 3",
-              "Farming Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 3",
-              "Farming Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 3",
-              "Farming Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 4",
-              "Farming Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 4",
-              "Farming Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 4",
-              "Farming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -266,16 +86,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Farming Level 5",
-              "Farming Level V"
+              "Farming Level 2",
+              "Farming Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -294,8 +111,8 @@
           },
           {
             "name": [
-              "Farming Level 5",
-              "Farming Level V"
+              "Farming Level 2",
+              "Farming Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -314,8 +131,8 @@
           },
           {
             "name": [
-              "Farming Level 5",
-              "Farming Level V"
+              "Farming Level 2",
+              "Farming Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -334,8 +151,8 @@
           },
           {
             "name": [
-              "Farming Level 6",
-              "Farming Level VI"
+              "Farming Level 3",
+              "Farming Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -354,8 +171,8 @@
           },
           {
             "name": [
-              "Farming Level 6",
-              "Farming Level VI"
+              "Farming Level 3",
+              "Farming Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -374,8 +191,8 @@
           },
           {
             "name": [
-              "Farming Level 6",
-              "Farming Level VI"
+              "Farming Level 3",
+              "Farming Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -394,8 +211,8 @@
           },
           {
             "name": [
-              "Farming Level 7",
-              "Farming Level VII"
+              "Farming Level 4",
+              "Farming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -414,8 +231,8 @@
           },
           {
             "name": [
-              "Farming Level 7",
-              "Farming Level VII"
+              "Farming Level 4",
+              "Farming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -434,8 +251,8 @@
           },
           {
             "name": [
-              "Farming Level 7",
-              "Farming Level VII"
+              "Farming Level 4",
+              "Farming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -449,13 +266,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Farming Level 8",
-              "Farming Level VIII"
+              "Farming Level 5",
+              "Farming Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -474,8 +294,8 @@
           },
           {
             "name": [
-              "Farming Level 8",
-              "Farming Level VIII"
+              "Farming Level 5",
+              "Farming Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -494,8 +314,8 @@
           },
           {
             "name": [
-              "Farming Level 8",
-              "Farming Level VIII"
+              "Farming Level 5",
+              "Farming Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Farming Level 9",
-              "Farming Level IX"
+              "Farming Level 6",
+              "Farming Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,8 +354,8 @@
           },
           {
             "name": [
-              "Farming Level 9",
-              "Farming Level IX"
+              "Farming Level 6",
+              "Farming Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -554,8 +374,8 @@
           },
           {
             "name": [
-              "Farming Level 9",
-              "Farming Level IX"
+              "Farming Level 6",
+              "Farming Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -569,16 +389,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Farming Level 10",
-              "Farming Level X"
+              "Farming Level 7",
+              "Farming Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -597,8 +414,8 @@
           },
           {
             "name": [
-              "Farming Level 10",
-              "Farming Level X"
+              "Farming Level 7",
+              "Farming Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -617,8 +434,8 @@
           },
           {
             "name": [
-              "Farming Level 10",
-              "Farming Level X"
+              "Farming Level 7",
+              "Farming Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -637,8 +454,8 @@
           },
           {
             "name": [
-              "Farming Level 11",
-              "Farming Level XI"
+              "Farming Level 8",
+              "Farming Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -657,8 +474,8 @@
           },
           {
             "name": [
-              "Farming Level 11",
-              "Farming Level XI"
+              "Farming Level 8",
+              "Farming Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -677,8 +494,8 @@
           },
           {
             "name": [
-              "Farming Level 11",
-              "Farming Level XI"
+              "Farming Level 8",
+              "Farming Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -697,8 +514,8 @@
           },
           {
             "name": [
-              "Farming Level 12",
-              "Farming Level XII"
+              "Farming Level 9",
+              "Farming Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -717,8 +534,8 @@
           },
           {
             "name": [
-              "Farming Level 12",
-              "Farming Level XII"
+              "Farming Level 9",
+              "Farming Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -737,8 +554,8 @@
           },
           {
             "name": [
-              "Farming Level 12",
-              "Farming Level XII"
+              "Farming Level 9",
+              "Farming Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -752,13 +569,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Farming Level 13",
-              "Farming Level XIII"
+              "Farming Level 10",
+              "Farming Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -777,8 +597,8 @@
           },
           {
             "name": [
-              "Farming Level 13",
-              "Farming Level XIII"
+              "Farming Level 10",
+              "Farming Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -797,8 +617,8 @@
           },
           {
             "name": [
-              "Farming Level 13",
-              "Farming Level XIII"
+              "Farming Level 10",
+              "Farming Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Farming Level 14",
-              "Farming Level XIV"
+              "Farming Level 11",
+              "Farming Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,8 +657,8 @@
           },
           {
             "name": [
-              "Farming Level 14",
-              "Farming Level XIV"
+              "Farming Level 11",
+              "Farming Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -857,8 +677,8 @@
           },
           {
             "name": [
-              "Farming Level 14",
-              "Farming Level XIV"
+              "Farming Level 11",
+              "Farming Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -872,16 +692,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Farming Level 15",
-              "Farming Level XV"
+              "Farming Level 12",
+              "Farming Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -900,8 +717,8 @@
           },
           {
             "name": [
-              "Farming Level 15",
-              "Farming Level XV"
+              "Farming Level 12",
+              "Farming Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -920,8 +737,8 @@
           },
           {
             "name": [
-              "Farming Level 15",
-              "Farming Level XV"
+              "Farming Level 12",
+              "Farming Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -940,8 +757,8 @@
           },
           {
             "name": [
-              "Farming Level 16",
-              "Farming Level XVI"
+              "Farming Level 13",
+              "Farming Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -960,8 +777,8 @@
           },
           {
             "name": [
-              "Farming Level 16",
-              "Farming Level XVI"
+              "Farming Level 13",
+              "Farming Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -980,8 +797,8 @@
           },
           {
             "name": [
-              "Farming Level 16",
-              "Farming Level XVI"
+              "Farming Level 13",
+              "Farming Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1000,8 +817,8 @@
           },
           {
             "name": [
-              "Farming Level 17",
-              "Farming Level XVII"
+              "Farming Level 14",
+              "Farming Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1020,8 +837,8 @@
           },
           {
             "name": [
-              "Farming Level 17",
-              "Farming Level XVII"
+              "Farming Level 14",
+              "Farming Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1040,8 +857,8 @@
           },
           {
             "name": [
-              "Farming Level 17",
-              "Farming Level XVII"
+              "Farming Level 14",
+              "Farming Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1055,13 +872,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Farming Level 18",
-              "Farming Level XVIII"
+              "Farming Level 15",
+              "Farming Level XV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1080,6 +900,166 @@
           },
           {
             "name": [
+              "Farming Level 15",
+              "Farming Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 15",
+              "Farming Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 16",
+              "Farming Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 16",
+              "Farming Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 16",
+              "Farming Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 17",
+              "Farming Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 17",
+              "Farming Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 17",
+              "Farming Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Farming Level 18",
               "Farming Level XVIII"
             ],
@@ -1091,7 +1071,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/locked/down_right",
+      "id": "skyblock_gui:skills/farming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 18",
+              "Farming Level XVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1111,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "id": "skyblock_gui:skills/farming/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1131,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "id": "skyblock_gui:skills/farming/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "id": "skyblock_gui:skills/farming/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/unlocked/left_down",
+      "id": "skyblock_gui:skills/farming/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -1194,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/unlocking/left_down",
+      "id": "skyblock_gui:skills/farming/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1205,6 +1205,429 @@
             "name": [
               "Farming Level 20",
               "Farming Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 20",
+              "Farming Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 21",
+              "Farming Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 21",
+              "Farming Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 21",
+              "Farming Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 22",
+              "Farming Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 22",
+              "Farming Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 22",
+              "Farming Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 23",
+              "Farming Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 23",
+              "Farming Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 23",
+              "Farming Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 24",
+              "Farming Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 24",
+              "Farming Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 24",
+              "Farming Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 25",
+              "Farming Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 25",
+              "Farming Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 25",
+              "Farming Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 26",
+              "Farming Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 26",
+              "Farming Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 26",
+              "Farming Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 27",
+              "Farming Level XXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 27",
+              "Farming Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1646,8 @@
           },
           {
             "name": [
-              "Farming Level 20",
-              "Farming Level XX"
+              "Farming Level 27",
+              "Farming Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1666,8 @@
           },
           {
             "name": [
-              "Farming Level 21",
-              "Farming Level XXI"
+              "Farming Level 28",
+              "Farming Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1686,8 @@
           },
           {
             "name": [
-              "Farming Level 21",
-              "Farming Level XXI"
+              "Farming Level 28",
+              "Farming Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1706,8 @@
           },
           {
             "name": [
-              "Farming Level 21",
-              "Farming Level XXI"
+              "Farming Level 28",
+              "Farming Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1726,8 @@
           },
           {
             "name": [
-              "Farming Level 22",
-              "Farming Level XXII"
+              "Farming Level 29",
+              "Farming Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1746,8 @@
           },
           {
             "name": [
-              "Farming Level 22",
-              "Farming Level XXII"
+              "Farming Level 29",
+              "Farming Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,8 +1766,494 @@
           },
           {
             "name": [
-              "Farming Level 22",
-              "Farming Level XXII"
+              "Farming Level 29",
+              "Farming Level XXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 30",
+              "Farming Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 30",
+              "Farming Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 30",
+              "Farming Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 31",
+              "Farming Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 31",
+              "Farming Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 31",
+              "Farming Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 32",
+              "Farming Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 32",
+              "Farming Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 32",
+              "Farming Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 33",
+              "Farming Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 33",
+              "Farming Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 33",
+              "Farming Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 34",
+              "Farming Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 34",
+              "Farming Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 34",
+              "Farming Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 35",
+              "Farming Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 35",
+              "Farming Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 35",
+              "Farming Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 36",
+              "Farming Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 36",
+              "Farming Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 36",
+              "Farming Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 37",
+              "Farming Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 37",
+              "Farming Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 37",
+              "Farming Level XXXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1363,8 +2272,8 @@
           },
           {
             "name": [
-              "Farming Level 23",
-              "Farming Level XXIII"
+              "Farming Level 38",
+              "Farming Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1383,8 +2292,8 @@
           },
           {
             "name": [
-              "Farming Level 23",
-              "Farming Level XXIII"
+              "Farming Level 38",
+              "Farming Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1403,8 +2312,8 @@
           },
           {
             "name": [
-              "Farming Level 23",
-              "Farming Level XXIII"
+              "Farming Level 38",
+              "Farming Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1423,8 +2332,8 @@
           },
           {
             "name": [
-              "Farming Level 24",
-              "Farming Level XXIV"
+              "Farming Level 39",
+              "Farming Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1443,8 +2352,8 @@
           },
           {
             "name": [
-              "Farming Level 24",
-              "Farming Level XXIV"
+              "Farming Level 39",
+              "Farming Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1463,8 +2372,1220 @@
           },
           {
             "name": [
-              "Farming Level 24",
-              "Farming Level XXIV"
+              "Farming Level 39",
+              "Farming Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 40",
+              "Farming Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 40",
+              "Farming Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 40",
+              "Farming Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 41",
+              "Farming Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 41",
+              "Farming Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 41",
+              "Farming Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 42",
+              "Farming Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 42",
+              "Farming Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 42",
+              "Farming Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 43",
+              "Farming Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 43",
+              "Farming Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 43",
+              "Farming Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 44",
+              "Farming Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 44",
+              "Farming Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 44",
+              "Farming Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 45",
+              "Farming Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 45",
+              "Farming Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 45",
+              "Farming Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 46",
+              "Farming Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 46",
+              "Farming Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 46",
+              "Farming Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 47",
+              "Farming Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 47",
+              "Farming Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 47",
+              "Farming Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 48",
+              "Farming Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 48",
+              "Farming Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 48",
+              "Farming Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 49",
+              "Farming Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 49",
+              "Farming Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 49",
+              "Farming Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 50",
+              "Farming Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 50",
+              "Farming Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 50",
+              "Farming Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 51",
+              "Farming Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 51",
+              "Farming Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 51",
+              "Farming Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 52",
+              "Farming Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 52",
+              "Farming Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 52",
+              "Farming Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 53",
+              "Farming Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 53",
+              "Farming Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 53",
+              "Farming Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 54",
+              "Farming Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 54",
+              "Farming Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 54",
+              "Farming Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:hay_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 55",
+              "Farming Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 55",
+              "Farming Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 55",
+              "Farming Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 56",
+              "Farming Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 56",
+              "Farming Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 56",
+              "Farming Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 57",
+              "Farming Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 57",
+              "Farming Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 57",
+              "Farming Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 58",
+              "Farming Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 58",
+              "Farming Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 58",
+              "Farming Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 59",
+              "Farming Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 59",
+              "Farming Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/farming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Farming Level 59",
+              "Farming Level LIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1475,2127 +3596,6 @@
     },
     {
       "id": "skyblock_gui:skills/farming/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 25",
-              "Farming Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 25",
-              "Farming Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 25",
-              "Farming Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 26",
-              "Farming Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 26",
-              "Farming Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 26",
-              "Farming Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 27",
-              "Farming Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 27",
-              "Farming Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 27",
-              "Farming Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 28",
-              "Farming Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 28",
-              "Farming Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 28",
-              "Farming Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 29",
-              "Farming Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 29",
-              "Farming Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 29",
-              "Farming Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 30",
-              "Farming Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 30",
-              "Farming Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 30",
-              "Farming Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 31",
-              "Farming Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 31",
-              "Farming Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 31",
-              "Farming Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 32",
-              "Farming Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 32",
-              "Farming Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 32",
-              "Farming Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 33",
-              "Farming Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 33",
-              "Farming Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 33",
-              "Farming Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 34",
-              "Farming Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 34",
-              "Farming Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 34",
-              "Farming Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 35",
-              "Farming Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 35",
-              "Farming Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 35",
-              "Farming Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 36",
-              "Farming Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 36",
-              "Farming Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 36",
-              "Farming Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 37",
-              "Farming Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 37",
-              "Farming Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 37",
-              "Farming Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 38",
-              "Farming Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 38",
-              "Farming Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 38",
-              "Farming Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 39",
-              "Farming Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 39",
-              "Farming Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 39",
-              "Farming Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 40",
-              "Farming Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 40",
-              "Farming Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 40",
-              "Farming Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 41",
-              "Farming Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 41",
-              "Farming Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 41",
-              "Farming Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 42",
-              "Farming Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 42",
-              "Farming Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 42",
-              "Farming Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 43",
-              "Farming Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 43",
-              "Farming Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 43",
-              "Farming Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 44",
-              "Farming Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 44",
-              "Farming Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 44",
-              "Farming Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 45",
-              "Farming Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 45",
-              "Farming Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 45",
-              "Farming Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 46",
-              "Farming Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 46",
-              "Farming Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 46",
-              "Farming Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 47",
-              "Farming Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 47",
-              "Farming Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 47",
-              "Farming Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 48",
-              "Farming Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 48",
-              "Farming Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 48",
-              "Farming Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 49",
-              "Farming Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 49",
-              "Farming Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 49",
-              "Farming Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 50",
-              "Farming Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 50",
-              "Farming Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 50",
-              "Farming Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 51",
-              "Farming Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 51",
-              "Farming Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 51",
-              "Farming Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 52",
-              "Farming Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 52",
-              "Farming Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 52",
-              "Farming Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 53",
-              "Farming Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 53",
-              "Farming Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 53",
-              "Farming Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 54",
-              "Farming Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 54",
-              "Farming Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 54",
-              "Farming Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:hay_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 55",
-              "Farming Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 55",
-              "Farming Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 55",
-              "Farming Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 56",
-              "Farming Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 56",
-              "Farming Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 56",
-              "Farming Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 57",
-              "Farming Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 57",
-              "Farming Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 57",
-              "Farming Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 58",
-              "Farming Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 58",
-              "Farming Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 58",
-              "Farming Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 59",
-              "Farming Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 59",
-              "Farming Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Farming Level 59",
-              "Farming Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/farming/unlocked/left_end",
       "target": {
         "conditions": [
           {
@@ -3618,7 +3618,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/unlocking/left_end",
+      "id": "skyblock_gui:skills/farming/unlocking/up_end",
       "target": {
         "conditions": [
           {
@@ -3638,7 +3638,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/farming/locked/left_end",
+      "id": "skyblock_gui:skills/farming/locked/up_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/fishing.json
+++ b/repo/guis/skills/fishing.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/start_down",
+      "id": "skyblock_gui:skills/fishing/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/start_down",
+      "id": "skyblock_gui:skills/fishing/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/start_down",
+      "id": "skyblock_gui:skills/fishing/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Fishing Level 1",
               "Fishing Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 2",
-              "Fishing Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 2",
-              "Fishing Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 2",
-              "Fishing Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 3",
-              "Fishing Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 3",
-              "Fishing Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 3",
-              "Fishing Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 4",
-              "Fishing Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 4",
-              "Fishing Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 4",
-              "Fishing Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:skills/fishing/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 2",
+              "Fishing Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 2",
+              "Fishing Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 2",
+              "Fishing Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 3",
+              "Fishing Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 3",
+              "Fishing Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 3",
+              "Fishing Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 4",
+              "Fishing Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 4",
+              "Fishing Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 4",
+              "Fishing Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/left_up",
+      "id": "skyblock_gui:skills/fishing/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/left_up",
+      "id": "skyblock_gui:skills/fishing/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 6",
-              "Fishing Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 6",
-              "Fishing Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 6",
-              "Fishing Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 7",
-              "Fishing Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 7",
-              "Fishing Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 7",
-              "Fishing Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 8",
-              "Fishing Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 8",
-              "Fishing Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 8",
-              "Fishing Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/fishing/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Fishing Level 9",
-              "Fishing Level IX"
+              "Fishing Level 6",
+              "Fishing Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Fishing Level 6",
+              "Fishing Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 6",
+              "Fishing Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 7",
+              "Fishing Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 7",
+              "Fishing Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 7",
+              "Fishing Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 8",
+              "Fishing Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 8",
+              "Fishing Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 8",
+              "Fishing Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Fishing Level 9",
               "Fishing Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/left_right",
+      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 9",
+              "Fishing Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/left_down",
+      "id": "skyblock_gui:skills/fishing/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/left_down",
+      "id": "skyblock_gui:skills/fishing/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/left_down",
+      "id": "skyblock_gui:skills/fishing/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 11",
-              "Fishing Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 11",
-              "Fishing Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 11",
-              "Fishing Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 12",
-              "Fishing Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 12",
-              "Fishing Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 12",
-              "Fishing Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 13",
-              "Fishing Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 13",
-              "Fishing Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 13",
-              "Fishing Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/fishing/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Fishing Level 14",
-              "Fishing Level XIV"
+              "Fishing Level 11",
+              "Fishing Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Fishing Level 11",
+              "Fishing Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 11",
+              "Fishing Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 12",
+              "Fishing Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 12",
+              "Fishing Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 12",
+              "Fishing Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 13",
+              "Fishing Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 13",
+              "Fishing Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 13",
+              "Fishing Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Fishing Level 14",
               "Fishing Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/left_right",
+      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 14",
+              "Fishing Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/left_up",
+      "id": "skyblock_gui:skills/fishing/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/left_up",
+      "id": "skyblock_gui:skills/fishing/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/left_up",
+      "id": "skyblock_gui:skills/fishing/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 16",
-              "Fishing Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 16",
-              "Fishing Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 16",
-              "Fishing Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 17",
-              "Fishing Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 17",
-              "Fishing Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 17",
-              "Fishing Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 18",
-              "Fishing Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 18",
-              "Fishing Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 18",
-              "Fishing Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/fishing/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Fishing Level 19",
-              "Fishing Level XIX"
+              "Fishing Level 16",
+              "Fishing Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Fishing Level 19",
-              "Fishing Level XIX"
+              "Fishing Level 16",
+              "Fishing Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Fishing Level 19",
-              "Fishing Level XIX"
+              "Fishing Level 16",
+              "Fishing Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:prismarine"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 20",
-              "Fishing Level XX"
+              "Fishing Level 17",
+              "Fishing Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Fishing Level 20",
-              "Fishing Level XX"
+              "Fishing Level 17",
+              "Fishing Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Fishing Level 20",
-              "Fishing Level XX"
+              "Fishing Level 17",
+              "Fishing Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Fishing Level 21",
-              "Fishing Level XXI"
+              "Fishing Level 18",
+              "Fishing Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Fishing Level 21",
-              "Fishing Level XXI"
+              "Fishing Level 18",
+              "Fishing Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Fishing Level 21",
-              "Fishing Level XXI"
+              "Fishing Level 18",
+              "Fishing Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Fishing Level 22",
-              "Fishing Level XXII"
+              "Fishing Level 19",
+              "Fishing Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Fishing Level 22",
-              "Fishing Level XXII"
+              "Fishing Level 19",
+              "Fishing Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Fishing Level 22",
-              "Fishing Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 23",
-              "Fishing Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 23",
-              "Fishing Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 23",
-              "Fishing Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 24",
-              "Fishing Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 24",
-              "Fishing Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 24",
-              "Fishing Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:prismarine"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 25",
-              "Fishing Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 25",
-              "Fishing Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 25",
-              "Fishing Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 26",
-              "Fishing Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 26",
-              "Fishing Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 26",
-              "Fishing Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 27",
-              "Fishing Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 27",
-              "Fishing Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Fishing Level 27",
-              "Fishing Level XXVII"
+              "Fishing Level 19",
+              "Fishing Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 28",
-              "Fishing Level XXVIII"
+              "Fishing Level 20",
+              "Fishing Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Fishing Level 28",
-              "Fishing Level XXVIII"
+              "Fishing Level 20",
+              "Fishing Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Fishing Level 28",
-              "Fishing Level XXVIII"
+              "Fishing Level 20",
+              "Fishing Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Fishing Level 29",
-              "Fishing Level XXIX"
+              "Fishing Level 21",
+              "Fishing Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Fishing Level 29",
-              "Fishing Level XXIX"
+              "Fishing Level 21",
+              "Fishing Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Fishing Level 29",
-              "Fishing Level XXIX"
+              "Fishing Level 21",
+              "Fishing Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:prismarine"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 30",
-              "Fishing Level XXX"
+              "Fishing Level 22",
+              "Fishing Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Fishing Level 30",
-              "Fishing Level XXX"
+              "Fishing Level 22",
+              "Fishing Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Fishing Level 30",
-              "Fishing Level XXX"
+              "Fishing Level 22",
+              "Fishing Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Fishing Level 31",
-              "Fishing Level XXXI"
+              "Fishing Level 23",
+              "Fishing Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Fishing Level 31",
-              "Fishing Level XXXI"
+              "Fishing Level 23",
+              "Fishing Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Fishing Level 31",
-              "Fishing Level XXXI"
+              "Fishing Level 23",
+              "Fishing Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Fishing Level 32",
-              "Fishing Level XXXII"
+              "Fishing Level 24",
+              "Fishing Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Fishing Level 32",
-              "Fishing Level XXXII"
+              "Fishing Level 24",
+              "Fishing Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Fishing Level 32",
-              "Fishing Level XXXII"
+              "Fishing Level 24",
+              "Fishing Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 33",
-              "Fishing Level XXXIII"
+              "Fishing Level 25",
+              "Fishing Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Fishing Level 33",
-              "Fishing Level XXXIII"
+              "Fishing Level 25",
+              "Fishing Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Fishing Level 33",
-              "Fishing Level XXXIII"
+              "Fishing Level 25",
+              "Fishing Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Fishing Level 34",
-              "Fishing Level XXXIV"
+              "Fishing Level 26",
+              "Fishing Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Fishing Level 34",
-              "Fishing Level XXXIV"
+              "Fishing Level 26",
+              "Fishing Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Fishing Level 34",
-              "Fishing Level XXXIV"
+              "Fishing Level 26",
+              "Fishing Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:prismarine"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 35",
-              "Fishing Level XXXV"
+              "Fishing Level 27",
+              "Fishing Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Fishing Level 35",
-              "Fishing Level XXXV"
+              "Fishing Level 27",
+              "Fishing Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Fishing Level 35",
-              "Fishing Level XXXV"
+              "Fishing Level 27",
+              "Fishing Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Fishing Level 36",
-              "Fishing Level XXXVI"
+              "Fishing Level 28",
+              "Fishing Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Fishing Level 36",
-              "Fishing Level XXXVI"
+              "Fishing Level 28",
+              "Fishing Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Fishing Level 36",
-              "Fishing Level XXXVI"
+              "Fishing Level 28",
+              "Fishing Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Fishing Level 37",
-              "Fishing Level XXXVII"
+              "Fishing Level 29",
+              "Fishing Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Fishing Level 37",
-              "Fishing Level XXXVII"
+              "Fishing Level 29",
+              "Fishing Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Fishing Level 37",
-              "Fishing Level XXXVII"
+              "Fishing Level 29",
+              "Fishing Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 38",
-              "Fishing Level XXXVIII"
+              "Fishing Level 30",
+              "Fishing Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Fishing Level 38",
-              "Fishing Level XXXVIII"
+              "Fishing Level 30",
+              "Fishing Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Fishing Level 38",
-              "Fishing Level XXXVIII"
+              "Fishing Level 30",
+              "Fishing Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Fishing Level 39",
-              "Fishing Level XXXIX"
+              "Fishing Level 31",
+              "Fishing Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Fishing Level 39",
-              "Fishing Level XXXIX"
+              "Fishing Level 31",
+              "Fishing Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Fishing Level 39",
-              "Fishing Level XXXIX"
+              "Fishing Level 31",
+              "Fishing Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:prismarine"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 40",
-              "Fishing Level XL"
+              "Fishing Level 32",
+              "Fishing Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Fishing Level 40",
-              "Fishing Level XL"
+              "Fishing Level 32",
+              "Fishing Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Fishing Level 40",
-              "Fishing Level XL"
+              "Fishing Level 32",
+              "Fishing Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Fishing Level 41",
-              "Fishing Level XLI"
+              "Fishing Level 33",
+              "Fishing Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Fishing Level 41",
-              "Fishing Level XLI"
+              "Fishing Level 33",
+              "Fishing Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Fishing Level 41",
-              "Fishing Level XLI"
+              "Fishing Level 33",
+              "Fishing Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Fishing Level 42",
-              "Fishing Level XLII"
+              "Fishing Level 34",
+              "Fishing Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Fishing Level 42",
-              "Fishing Level XLII"
+              "Fishing Level 34",
+              "Fishing Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Fishing Level 42",
-              "Fishing Level XLII"
+              "Fishing Level 34",
+              "Fishing Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Fishing Level 43",
-              "Fishing Level XLIII"
+              "Fishing Level 35",
+              "Fishing Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Fishing Level 35",
+              "Fishing Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 35",
+              "Fishing Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 36",
+              "Fishing Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 36",
+              "Fishing Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 36",
+              "Fishing Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 37",
+              "Fishing Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 37",
+              "Fishing Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 37",
+              "Fishing Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 38",
+              "Fishing Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 38",
+              "Fishing Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 38",
+              "Fishing Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 39",
+              "Fishing Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 39",
+              "Fishing Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 39",
+              "Fishing Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 40",
+              "Fishing Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 40",
+              "Fishing Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 40",
+              "Fishing Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 41",
+              "Fishing Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 41",
+              "Fishing Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 41",
+              "Fishing Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 42",
+              "Fishing Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 42",
+              "Fishing Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 42",
+              "Fishing Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Fishing Level 43",
               "Fishing Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/down_right",
+      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Fishing Level 43",
+              "Fishing Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/fishing/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/left_right",
+      "id": "skyblock_gui:skills/fishing/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/left_right",
+      "id": "skyblock_gui:skills/fishing/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/left_right",
+      "id": "skyblock_gui:skills/fishing/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/left_down",
+      "id": "skyblock_gui:skills/fishing/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/left_down",
+      "id": "skyblock_gui:skills/fishing/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/left_down",
+      "id": "skyblock_gui:skills/fishing/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
+      "id": "skyblock_gui:skills/fishing/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
+      "id": "skyblock_gui:skills/fishing/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
+      "id": "skyblock_gui:skills/fishing/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocked/up_down",
+      "id": "skyblock_gui:skills/fishing/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/unlocking/up_down",
+      "id": "skyblock_gui:skills/fishing/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/fishing/locked/up_down",
+      "id": "skyblock_gui:skills/fishing/locked/left_down",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/foraging.json
+++ b/repo/guis/skills/foraging.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/start_down",
+      "id": "skyblock_gui:skills/foraging/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/start_down",
+      "id": "skyblock_gui:skills/foraging/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/start_down",
+      "id": "skyblock_gui:skills/foraging/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Foraging Level 1",
               "Foraging Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 2",
-              "Foraging Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 2",
-              "Foraging Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 2",
-              "Foraging Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 3",
-              "Foraging Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 3",
-              "Foraging Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 3",
-              "Foraging Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 4",
-              "Foraging Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 4",
-              "Foraging Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 4",
-              "Foraging Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -263,6 +83,186 @@
     },
     {
       "id": "skyblock_gui:skills/foraging/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 2",
+              "Foraging Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 2",
+              "Foraging Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 2",
+              "Foraging Level II"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 3",
+              "Foraging Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 3",
+              "Foraging Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 3",
+              "Foraging Level III"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 4",
+              "Foraging Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 4",
+              "Foraging Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 4",
+              "Foraging Level IV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/left_up",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_up",
+      "id": "skyblock_gui:skills/foraging/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -325,186 +325,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 6",
-              "Foraging Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 6",
-              "Foraging Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 6",
-              "Foraging Level VI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 7",
-              "Foraging Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 7",
-              "Foraging Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 7",
-              "Foraging Level VII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 8",
-              "Foraging Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 8",
-              "Foraging Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 8",
-              "Foraging Level VIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/foraging/unlocked/left_right",
       "target": {
         "conditions": [
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Foraging Level 9",
-              "Foraging Level IX"
+              "Foraging Level 6",
+              "Foraging Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,6 +354,166 @@
           },
           {
             "name": [
+              "Foraging Level 6",
+              "Foraging Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 6",
+              "Foraging Level VI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 7",
+              "Foraging Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 7",
+              "Foraging Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 7",
+              "Foraging Level VII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 8",
+              "Foraging Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 8",
+              "Foraging Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 8",
+              "Foraging Level VIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Foraging Level 9",
               "Foraging Level IX"
             ],
@@ -545,7 +525,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 9",
+              "Foraging Level IX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/left_down",
+      "id": "skyblock_gui:skills/foraging/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -588,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/left_down",
+      "id": "skyblock_gui:skills/foraging/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -608,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_down",
+      "id": "skyblock_gui:skills/foraging/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -628,186 +628,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 11",
-              "Foraging Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 11",
-              "Foraging Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 11",
-              "Foraging Level XI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 12",
-              "Foraging Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 12",
-              "Foraging Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 12",
-              "Foraging Level XII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 13",
-              "Foraging Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 13",
-              "Foraging Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 13",
-              "Foraging Level XIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/foraging/unlocked/left_right",
       "target": {
         "conditions": [
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Foraging Level 14",
-              "Foraging Level XIV"
+              "Foraging Level 11",
+              "Foraging Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,6 +657,166 @@
           },
           {
             "name": [
+              "Foraging Level 11",
+              "Foraging Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 11",
+              "Foraging Level XI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 12",
+              "Foraging Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 12",
+              "Foraging Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 12",
+              "Foraging Level XII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 13",
+              "Foraging Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 13",
+              "Foraging Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 13",
+              "Foraging Level XIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Foraging Level 14",
               "Foraging Level XIV"
             ],
@@ -848,7 +828,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 14",
+              "Foraging Level XIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -868,7 +868,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/left_up",
+      "id": "skyblock_gui:skills/foraging/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -891,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/left_up",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -911,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_up",
+      "id": "skyblock_gui:skills/foraging/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -931,186 +931,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 16",
-              "Foraging Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 16",
-              "Foraging Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 16",
-              "Foraging Level XVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 17",
-              "Foraging Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 17",
-              "Foraging Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 17",
-              "Foraging Level XVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 18",
-              "Foraging Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 18",
-              "Foraging Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 18",
-              "Foraging Level XVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/foraging/unlocked/left_right",
       "target": {
         "conditions": [
@@ -1120,8 +940,8 @@
           },
           {
             "name": [
-              "Foraging Level 19",
-              "Foraging Level XIX"
+              "Foraging Level 16",
+              "Foraging Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1140,8 +960,8 @@
           },
           {
             "name": [
-              "Foraging Level 19",
-              "Foraging Level XIX"
+              "Foraging Level 16",
+              "Foraging Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1160,8 +980,8 @@
           },
           {
             "name": [
-              "Foraging Level 19",
-              "Foraging Level XIX"
+              "Foraging Level 16",
+              "Foraging Level XVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1175,16 +995,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:oak_log"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 20",
-              "Foraging Level XX"
+              "Foraging Level 17",
+              "Foraging Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1203,8 +1020,8 @@
           },
           {
             "name": [
-              "Foraging Level 20",
-              "Foraging Level XX"
+              "Foraging Level 17",
+              "Foraging Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1040,8 @@
           },
           {
             "name": [
-              "Foraging Level 20",
-              "Foraging Level XX"
+              "Foraging Level 17",
+              "Foraging Level XVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1060,8 @@
           },
           {
             "name": [
-              "Foraging Level 21",
-              "Foraging Level XXI"
+              "Foraging Level 18",
+              "Foraging Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1080,8 @@
           },
           {
             "name": [
-              "Foraging Level 21",
-              "Foraging Level XXI"
+              "Foraging Level 18",
+              "Foraging Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1100,8 @@
           },
           {
             "name": [
-              "Foraging Level 21",
-              "Foraging Level XXI"
+              "Foraging Level 18",
+              "Foraging Level XVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1120,8 @@
           },
           {
             "name": [
-              "Foraging Level 22",
-              "Foraging Level XXII"
+              "Foraging Level 19",
+              "Foraging Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1140,8 @@
           },
           {
             "name": [
-              "Foraging Level 22",
-              "Foraging Level XXII"
+              "Foraging Level 19",
+              "Foraging Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,311 +1160,8 @@
           },
           {
             "name": [
-              "Foraging Level 22",
-              "Foraging Level XXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 23",
-              "Foraging Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 23",
-              "Foraging Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 23",
-              "Foraging Level XXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 24",
-              "Foraging Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 24",
-              "Foraging Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 24",
-              "Foraging Level XXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:oak_log"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 25",
-              "Foraging Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 25",
-              "Foraging Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 25",
-              "Foraging Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 26",
-              "Foraging Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 26",
-              "Foraging Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 26",
-              "Foraging Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 27",
-              "Foraging Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 27",
-              "Foraging Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 27",
-              "Foraging Level XXVII"
+              "Foraging Level 19",
+              "Foraging Level XIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1661,13 +1175,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:oak_log"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 28",
-              "Foraging Level XXVIII"
+              "Foraging Level 20",
+              "Foraging Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1686,8 +1203,8 @@
           },
           {
             "name": [
-              "Foraging Level 28",
-              "Foraging Level XXVIII"
+              "Foraging Level 20",
+              "Foraging Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1706,8 +1223,8 @@
           },
           {
             "name": [
-              "Foraging Level 28",
-              "Foraging Level XXVIII"
+              "Foraging Level 20",
+              "Foraging Level XX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1726,8 +1243,8 @@
           },
           {
             "name": [
-              "Foraging Level 29",
-              "Foraging Level XXIX"
+              "Foraging Level 21",
+              "Foraging Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1746,8 +1263,8 @@
           },
           {
             "name": [
-              "Foraging Level 29",
-              "Foraging Level XXIX"
+              "Foraging Level 21",
+              "Foraging Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1766,8 +1283,8 @@
           },
           {
             "name": [
-              "Foraging Level 29",
-              "Foraging Level XXIX"
+              "Foraging Level 21",
+              "Foraging Level XXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1781,16 +1298,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:oak_log"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 30",
-              "Foraging Level XXX"
+              "Foraging Level 22",
+              "Foraging Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1809,8 +1323,8 @@
           },
           {
             "name": [
-              "Foraging Level 30",
-              "Foraging Level XXX"
+              "Foraging Level 22",
+              "Foraging Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1829,8 +1343,8 @@
           },
           {
             "name": [
-              "Foraging Level 30",
-              "Foraging Level XXX"
+              "Foraging Level 22",
+              "Foraging Level XXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1849,8 +1363,8 @@
           },
           {
             "name": [
-              "Foraging Level 31",
-              "Foraging Level XXXI"
+              "Foraging Level 23",
+              "Foraging Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1869,8 +1383,8 @@
           },
           {
             "name": [
-              "Foraging Level 31",
-              "Foraging Level XXXI"
+              "Foraging Level 23",
+              "Foraging Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1889,8 +1403,8 @@
           },
           {
             "name": [
-              "Foraging Level 31",
-              "Foraging Level XXXI"
+              "Foraging Level 23",
+              "Foraging Level XXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1909,8 +1423,8 @@
           },
           {
             "name": [
-              "Foraging Level 32",
-              "Foraging Level XXXII"
+              "Foraging Level 24",
+              "Foraging Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1929,8 +1443,8 @@
           },
           {
             "name": [
-              "Foraging Level 32",
-              "Foraging Level XXXII"
+              "Foraging Level 24",
+              "Foraging Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1949,8 +1463,8 @@
           },
           {
             "name": [
-              "Foraging Level 32",
-              "Foraging Level XXXII"
+              "Foraging Level 24",
+              "Foraging Level XXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1964,13 +1478,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:oak_log"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 33",
-              "Foraging Level XXXIII"
+              "Foraging Level 25",
+              "Foraging Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1989,8 +1506,8 @@
           },
           {
             "name": [
-              "Foraging Level 33",
-              "Foraging Level XXXIII"
+              "Foraging Level 25",
+              "Foraging Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2009,8 +1526,8 @@
           },
           {
             "name": [
-              "Foraging Level 33",
-              "Foraging Level XXXIII"
+              "Foraging Level 25",
+              "Foraging Level XXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2029,8 +1546,8 @@
           },
           {
             "name": [
-              "Foraging Level 34",
-              "Foraging Level XXXIV"
+              "Foraging Level 26",
+              "Foraging Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2049,8 +1566,8 @@
           },
           {
             "name": [
-              "Foraging Level 34",
-              "Foraging Level XXXIV"
+              "Foraging Level 26",
+              "Foraging Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2069,8 +1586,8 @@
           },
           {
             "name": [
-              "Foraging Level 34",
-              "Foraging Level XXXIV"
+              "Foraging Level 26",
+              "Foraging Level XXVI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2084,16 +1601,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:oak_log"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 35",
-              "Foraging Level XXXV"
+              "Foraging Level 27",
+              "Foraging Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2112,8 +1626,8 @@
           },
           {
             "name": [
-              "Foraging Level 35",
-              "Foraging Level XXXV"
+              "Foraging Level 27",
+              "Foraging Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2132,8 +1646,8 @@
           },
           {
             "name": [
-              "Foraging Level 35",
-              "Foraging Level XXXV"
+              "Foraging Level 27",
+              "Foraging Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2152,8 +1666,8 @@
           },
           {
             "name": [
-              "Foraging Level 36",
-              "Foraging Level XXXVI"
+              "Foraging Level 28",
+              "Foraging Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2172,8 +1686,8 @@
           },
           {
             "name": [
-              "Foraging Level 36",
-              "Foraging Level XXXVI"
+              "Foraging Level 28",
+              "Foraging Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2192,8 +1706,8 @@
           },
           {
             "name": [
-              "Foraging Level 36",
-              "Foraging Level XXXVI"
+              "Foraging Level 28",
+              "Foraging Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2212,8 +1726,8 @@
           },
           {
             "name": [
-              "Foraging Level 37",
-              "Foraging Level XXXVII"
+              "Foraging Level 29",
+              "Foraging Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2232,8 +1746,8 @@
           },
           {
             "name": [
-              "Foraging Level 37",
-              "Foraging Level XXXVII"
+              "Foraging Level 29",
+              "Foraging Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2252,8 +1766,8 @@
           },
           {
             "name": [
-              "Foraging Level 37",
-              "Foraging Level XXXVII"
+              "Foraging Level 29",
+              "Foraging Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2267,13 +1781,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:oak_log"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 38",
-              "Foraging Level XXXVIII"
+              "Foraging Level 30",
+              "Foraging Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2292,8 +1809,8 @@
           },
           {
             "name": [
-              "Foraging Level 38",
-              "Foraging Level XXXVIII"
+              "Foraging Level 30",
+              "Foraging Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2312,8 +1829,8 @@
           },
           {
             "name": [
-              "Foraging Level 38",
-              "Foraging Level XXXVIII"
+              "Foraging Level 30",
+              "Foraging Level XXX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2332,8 +1849,8 @@
           },
           {
             "name": [
-              "Foraging Level 39",
-              "Foraging Level XXXIX"
+              "Foraging Level 31",
+              "Foraging Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2352,8 +1869,8 @@
           },
           {
             "name": [
-              "Foraging Level 39",
-              "Foraging Level XXXIX"
+              "Foraging Level 31",
+              "Foraging Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2372,8 +1889,8 @@
           },
           {
             "name": [
-              "Foraging Level 39",
-              "Foraging Level XXXIX"
+              "Foraging Level 31",
+              "Foraging Level XXXI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2387,16 +1904,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:oak_log"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 40",
-              "Foraging Level XL"
+              "Foraging Level 32",
+              "Foraging Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2415,8 +1929,8 @@
           },
           {
             "name": [
-              "Foraging Level 40",
-              "Foraging Level XL"
+              "Foraging Level 32",
+              "Foraging Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2435,8 +1949,8 @@
           },
           {
             "name": [
-              "Foraging Level 40",
-              "Foraging Level XL"
+              "Foraging Level 32",
+              "Foraging Level XXXII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2455,8 +1969,8 @@
           },
           {
             "name": [
-              "Foraging Level 41",
-              "Foraging Level XLI"
+              "Foraging Level 33",
+              "Foraging Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2475,8 +1989,8 @@
           },
           {
             "name": [
-              "Foraging Level 41",
-              "Foraging Level XLI"
+              "Foraging Level 33",
+              "Foraging Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2495,8 +2009,8 @@
           },
           {
             "name": [
-              "Foraging Level 41",
-              "Foraging Level XLI"
+              "Foraging Level 33",
+              "Foraging Level XXXIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2515,8 +2029,8 @@
           },
           {
             "name": [
-              "Foraging Level 42",
-              "Foraging Level XLII"
+              "Foraging Level 34",
+              "Foraging Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2535,8 +2049,8 @@
           },
           {
             "name": [
-              "Foraging Level 42",
-              "Foraging Level XLII"
+              "Foraging Level 34",
+              "Foraging Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2555,8 +2069,8 @@
           },
           {
             "name": [
-              "Foraging Level 42",
-              "Foraging Level XLII"
+              "Foraging Level 34",
+              "Foraging Level XXXIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2570,13 +2084,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:oak_log"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Foraging Level 43",
-              "Foraging Level XLIII"
+              "Foraging Level 35",
+              "Foraging Level XXXV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -2595,6 +2112,469 @@
           },
           {
             "name": [
+              "Foraging Level 35",
+              "Foraging Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 35",
+              "Foraging Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 36",
+              "Foraging Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 36",
+              "Foraging Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 36",
+              "Foraging Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 37",
+              "Foraging Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 37",
+              "Foraging Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 37",
+              "Foraging Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 38",
+              "Foraging Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 38",
+              "Foraging Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 38",
+              "Foraging Level XXXVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 39",
+              "Foraging Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 39",
+              "Foraging Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 39",
+              "Foraging Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:oak_log"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 40",
+              "Foraging Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 40",
+              "Foraging Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 40",
+              "Foraging Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 41",
+              "Foraging Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 41",
+              "Foraging Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 41",
+              "Foraging Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 42",
+              "Foraging Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 42",
+              "Foraging Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 42",
+              "Foraging Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Foraging Level 43",
               "Foraging Level XLIII"
             ],
@@ -2606,7 +2586,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/down_right",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 43",
+              "Foraging Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2626,7 +2626,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/left_right",
+      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -2646,7 +2646,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/left_right",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -2666,7 +2666,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "id": "skyblock_gui:skills/foraging/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/left_down",
+      "id": "skyblock_gui:skills/foraging/unlocked/down_right",
       "target": {
         "conditions": [
           {
@@ -2709,7 +2709,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/left_down",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -2729,7 +2729,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_down",
+      "id": "skyblock_gui:skills/foraging/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -2749,7 +2749,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
+      "id": "skyblock_gui:skills/foraging/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -2769,7 +2769,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
+      "id": "skyblock_gui:skills/foraging/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -2789,7 +2789,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
+      "id": "skyblock_gui:skills/foraging/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -2809,7 +2809,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
+      "id": "skyblock_gui:skills/foraging/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -2829,7 +2829,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
+      "id": "skyblock_gui:skills/foraging/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -2849,7 +2849,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
+      "id": "skyblock_gui:skills/foraging/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -2989,7 +2989,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_end",
+      "id": "skyblock_gui:skills/foraging/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -3012,186 +3012,6 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 50",
-              "Foraging Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 50",
-              "Foraging Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 51",
-              "Foraging Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 51",
-              "Foraging Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 51",
-              "Foraging Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 52",
-              "Foraging Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 52",
-              "Foraging Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 52",
-              "Foraging Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/foraging/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Foraging Level 53",
-              "Foraging Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
       "id": "skyblock_gui:skills/foraging/unlocking/up_right",
       "target": {
         "conditions": [
@@ -3201,8 +3021,8 @@
           },
           {
             "name": [
-              "Foraging Level 53",
-              "Foraging Level LIII"
+              "Foraging Level 50",
+              "Foraging Level L"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -3221,6 +3041,146 @@
           },
           {
             "name": [
+              "Foraging Level 50",
+              "Foraging Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 51",
+              "Foraging Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 51",
+              "Foraging Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 51",
+              "Foraging Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 52",
+              "Foraging Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 52",
+              "Foraging Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 52",
+              "Foraging Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Foraging Level 53",
               "Foraging Level LIII"
             ],
@@ -3232,7 +3192,47 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocked/left_end",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 53",
+              "Foraging Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Foraging Level 53",
+              "Foraging Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/foraging/unlocked/down_end",
       "target": {
         "conditions": [
           {
@@ -3252,7 +3252,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/unlocking/left_end",
+      "id": "skyblock_gui:skills/foraging/unlocking/down_end",
       "target": {
         "conditions": [
           {
@@ -3272,7 +3272,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/foraging/locked/left_end",
+      "id": "skyblock_gui:skills/foraging/locked/down_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/hunting.json
+++ b/repo/guis/skills/hunting.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/start_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/start_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/start_down",
+      "id": "skyblock_gui:skills/hunting/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -82,7 +82,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
       "target": {
         "conditions": [
           {
@@ -102,7 +102,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
       "target": {
         "conditions": [
           {
@@ -122,7 +122,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
+      "id": "skyblock_gui:skills/hunting/locked/left_up",
       "target": {
         "conditions": [
           {
@@ -142,7 +142,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -162,7 +162,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -182,7 +182,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_right",
+      "id": "skyblock_gui:skills/hunting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -202,7 +202,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -222,7 +222,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -242,7 +242,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
+      "id": "skyblock_gui:skills/hunting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -262,11 +262,14 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_right",
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine_shard"
+            ],
             "type": "catharsis:item"
           },
           {
@@ -282,7 +285,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -302,7 +305,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_up",
+      "id": "skyblock_gui:skills/hunting/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -322,7 +325,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -342,7 +345,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -362,7 +365,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
+      "id": "skyblock_gui:skills/hunting/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -382,7 +385,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -402,7 +405,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -422,7 +425,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
+      "id": "skyblock_gui:skills/hunting/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -442,7 +445,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -462,7 +465,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -482,7 +485,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/down_right",
+      "id": "skyblock_gui:skills/hunting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -502,7 +505,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -522,7 +525,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -542,7 +545,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
+      "id": "skyblock_gui:skills/hunting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -562,11 +565,14 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/up_right",
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine_shard"
+            ],
             "type": "catharsis:item"
           },
           {
@@ -582,7 +588,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -602,7 +608,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_down",
+      "id": "skyblock_gui:skills/hunting/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -622,7 +628,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -642,7 +648,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -662,7 +668,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
+      "id": "skyblock_gui:skills/hunting/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -682,7 +688,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
       "target": {
         "conditions": [
           {
@@ -702,7 +708,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
       "target": {
         "conditions": [
           {
@@ -722,7 +728,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
+      "id": "skyblock_gui:skills/hunting/locked/left_up",
       "target": {
         "conditions": [
           {
@@ -742,7 +748,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -762,7 +768,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -782,7 +788,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_right",
+      "id": "skyblock_gui:skills/hunting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -802,7 +808,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -822,7 +828,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -842,7 +848,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
+      "id": "skyblock_gui:skills/hunting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -862,11 +868,14 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_right",
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine_shard"
+            ],
             "type": "catharsis:item"
           },
           {
@@ -882,7 +891,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_right",
       "target": {
         "conditions": [
           {
@@ -902,7 +911,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_up",
+      "id": "skyblock_gui:skills/hunting/locked/down_right",
       "target": {
         "conditions": [
           {
@@ -922,7 +931,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -942,7 +951,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -962,7 +971,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
+      "id": "skyblock_gui:skills/hunting/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -982,7 +991,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_down",
       "target": {
         "conditions": [
           {
@@ -1002,7 +1011,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_down",
       "target": {
         "conditions": [
           {
@@ -1022,7 +1031,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
+      "id": "skyblock_gui:skills/hunting/locked/left_down",
       "target": {
         "conditions": [
           {
@@ -1042,7 +1051,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1062,7 +1071,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1082,7 +1091,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/down_right",
+      "id": "skyblock_gui:skills/hunting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1102,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1122,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
+      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1142,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
+      "id": "skyblock_gui:skills/hunting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1162,11 +1171,14 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/up_right",
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine_shard"
+            ],
             "type": "catharsis:item"
           },
           {
@@ -1182,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1202,7 +1214,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/left_down",
+      "id": "skyblock_gui:skills/hunting/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -1222,7 +1234,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -1242,7 +1254,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -1262,7 +1274,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
+      "id": "skyblock_gui:skills/hunting/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -1282,7 +1294,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
       "target": {
         "conditions": [
           {
@@ -1302,7 +1314,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
       "target": {
         "conditions": [
           {
@@ -1322,7 +1334,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
+      "id": "skyblock_gui:skills/hunting/locked/left_up",
       "target": {
         "conditions": [
           {
@@ -1342,7 +1354,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -1362,7 +1374,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -1382,7 +1394,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
+      "id": "skyblock_gui:skills/hunting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -1402,7 +1414,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -1422,7 +1434,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -1442,7 +1454,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
+      "id": "skyblock_gui:skills/hunting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -1462,11 +1474,14 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_end",
+      "id": "skyblock_gui:skills/hunting/unlocked/down_end",
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:prismarine_shard"
+            ],
             "type": "catharsis:item"
           },
           {
@@ -1482,7 +1497,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_end",
+      "id": "skyblock_gui:skills/hunting/unlocking/down_end",
       "target": {
         "conditions": [
           {
@@ -1502,7 +1517,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/hunting/locked/up_end",
+      "id": "skyblock_gui:skills/hunting/locked/down_end",
       "target": {
         "conditions": [
           {
@@ -1513,2106 +1528,6 @@
             "name": [
               "Hunting Level 25",
               "Hunting Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 26",
-              "Hunting Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 26",
-              "Hunting Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 26",
-              "Hunting Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 27",
-              "Hunting Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 27",
-              "Hunting Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 27",
-              "Hunting Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 28",
-              "Hunting Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 28",
-              "Hunting Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 28",
-              "Hunting Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 29",
-              "Hunting Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 29",
-              "Hunting Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 29",
-              "Hunting Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 30",
-              "Hunting Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 30",
-              "Hunting Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 30",
-              "Hunting Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 31",
-              "Hunting Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 31",
-              "Hunting Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 31",
-              "Hunting Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 32",
-              "Hunting Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 32",
-              "Hunting Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 32",
-              "Hunting Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 33",
-              "Hunting Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 33",
-              "Hunting Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 33",
-              "Hunting Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 34",
-              "Hunting Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 34",
-              "Hunting Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 34",
-              "Hunting Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 35",
-              "Hunting Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 35",
-              "Hunting Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 35",
-              "Hunting Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 36",
-              "Hunting Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 36",
-              "Hunting Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 36",
-              "Hunting Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 37",
-              "Hunting Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 37",
-              "Hunting Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 37",
-              "Hunting Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 38",
-              "Hunting Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 38",
-              "Hunting Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 38",
-              "Hunting Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 39",
-              "Hunting Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 39",
-              "Hunting Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 39",
-              "Hunting Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 40",
-              "Hunting Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 40",
-              "Hunting Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 40",
-              "Hunting Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 41",
-              "Hunting Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 41",
-              "Hunting Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 41",
-              "Hunting Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 42",
-              "Hunting Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 42",
-              "Hunting Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 42",
-              "Hunting Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 43",
-              "Hunting Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 43",
-              "Hunting Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 43",
-              "Hunting Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 44",
-              "Hunting Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 44",
-              "Hunting Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 44",
-              "Hunting Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 45",
-              "Hunting Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 45",
-              "Hunting Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 45",
-              "Hunting Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 46",
-              "Hunting Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 46",
-              "Hunting Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 46",
-              "Hunting Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 47",
-              "Hunting Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 47",
-              "Hunting Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 47",
-              "Hunting Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 48",
-              "Hunting Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 48",
-              "Hunting Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 48",
-              "Hunting Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 49",
-              "Hunting Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 49",
-              "Hunting Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 49",
-              "Hunting Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 50",
-              "Hunting Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 50",
-              "Hunting Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 50",
-              "Hunting Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 51",
-              "Hunting Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 51",
-              "Hunting Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 51",
-              "Hunting Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 52",
-              "Hunting Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 52",
-              "Hunting Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 52",
-              "Hunting Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 53",
-              "Hunting Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 53",
-              "Hunting Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 53",
-              "Hunting Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 54",
-              "Hunting Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 54",
-              "Hunting Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 54",
-              "Hunting Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 55",
-              "Hunting Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 55",
-              "Hunting Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 55",
-              "Hunting Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 56",
-              "Hunting Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 56",
-              "Hunting Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 56",
-              "Hunting Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 57",
-              "Hunting Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 57",
-              "Hunting Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 57",
-              "Hunting Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 58",
-              "Hunting Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 58",
-              "Hunting Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 58",
-              "Hunting Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 59",
-              "Hunting Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 59",
-              "Hunting Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 59",
-              "Hunting Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocked/left_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 60",
-              "Hunting Level LX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/unlocking/left_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 60",
-              "Hunting Level LX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/hunting/locked/left_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Hunting Level 60",
-              "Hunting Level LX"
             ],
             "mode": "equals",
             "type": "catharsis:name"

--- a/repo/guis/skills/mining.json
+++ b/repo/guis/skills/mining.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/unlocked/start_down",
+      "id": "skyblock_gui:skills/mining/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/unlocking/start_down",
+      "id": "skyblock_gui:skills/mining/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/locked/start_down",
+      "id": "skyblock_gui:skills/mining/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Mining Level 1",
               "Mining Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 2",
-              "Mining Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 2",
-              "Mining Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 2",
-              "Mining Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 3",
-              "Mining Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 3",
-              "Mining Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 3",
-              "Mining Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 4",
-              "Mining Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 4",
-              "Mining Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 4",
-              "Mining Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -266,16 +86,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mining Level 5",
-              "Mining Level V"
+              "Mining Level 2",
+              "Mining Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -294,8 +111,8 @@
           },
           {
             "name": [
-              "Mining Level 5",
-              "Mining Level V"
+              "Mining Level 2",
+              "Mining Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -314,8 +131,8 @@
           },
           {
             "name": [
-              "Mining Level 5",
-              "Mining Level V"
+              "Mining Level 2",
+              "Mining Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -334,8 +151,8 @@
           },
           {
             "name": [
-              "Mining Level 6",
-              "Mining Level VI"
+              "Mining Level 3",
+              "Mining Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -354,8 +171,8 @@
           },
           {
             "name": [
-              "Mining Level 6",
-              "Mining Level VI"
+              "Mining Level 3",
+              "Mining Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -374,8 +191,8 @@
           },
           {
             "name": [
-              "Mining Level 6",
-              "Mining Level VI"
+              "Mining Level 3",
+              "Mining Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -394,8 +211,8 @@
           },
           {
             "name": [
-              "Mining Level 7",
-              "Mining Level VII"
+              "Mining Level 4",
+              "Mining Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -414,8 +231,8 @@
           },
           {
             "name": [
-              "Mining Level 7",
-              "Mining Level VII"
+              "Mining Level 4",
+              "Mining Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -434,8 +251,8 @@
           },
           {
             "name": [
-              "Mining Level 7",
-              "Mining Level VII"
+              "Mining Level 4",
+              "Mining Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -449,13 +266,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mining Level 8",
-              "Mining Level VIII"
+              "Mining Level 5",
+              "Mining Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -474,8 +294,8 @@
           },
           {
             "name": [
-              "Mining Level 8",
-              "Mining Level VIII"
+              "Mining Level 5",
+              "Mining Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -494,8 +314,8 @@
           },
           {
             "name": [
-              "Mining Level 8",
-              "Mining Level VIII"
+              "Mining Level 5",
+              "Mining Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Mining Level 9",
-              "Mining Level IX"
+              "Mining Level 6",
+              "Mining Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,8 +354,8 @@
           },
           {
             "name": [
-              "Mining Level 9",
-              "Mining Level IX"
+              "Mining Level 6",
+              "Mining Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -554,8 +374,8 @@
           },
           {
             "name": [
-              "Mining Level 9",
-              "Mining Level IX"
+              "Mining Level 6",
+              "Mining Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -569,16 +389,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mining Level 10",
-              "Mining Level X"
+              "Mining Level 7",
+              "Mining Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -597,8 +414,8 @@
           },
           {
             "name": [
-              "Mining Level 10",
-              "Mining Level X"
+              "Mining Level 7",
+              "Mining Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -617,8 +434,8 @@
           },
           {
             "name": [
-              "Mining Level 10",
-              "Mining Level X"
+              "Mining Level 7",
+              "Mining Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -637,8 +454,8 @@
           },
           {
             "name": [
-              "Mining Level 11",
-              "Mining Level XI"
+              "Mining Level 8",
+              "Mining Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -657,8 +474,8 @@
           },
           {
             "name": [
-              "Mining Level 11",
-              "Mining Level XI"
+              "Mining Level 8",
+              "Mining Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -677,8 +494,8 @@
           },
           {
             "name": [
-              "Mining Level 11",
-              "Mining Level XI"
+              "Mining Level 8",
+              "Mining Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -697,8 +514,8 @@
           },
           {
             "name": [
-              "Mining Level 12",
-              "Mining Level XII"
+              "Mining Level 9",
+              "Mining Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -717,8 +534,8 @@
           },
           {
             "name": [
-              "Mining Level 12",
-              "Mining Level XII"
+              "Mining Level 9",
+              "Mining Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -737,8 +554,8 @@
           },
           {
             "name": [
-              "Mining Level 12",
-              "Mining Level XII"
+              "Mining Level 9",
+              "Mining Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -752,13 +569,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mining Level 13",
-              "Mining Level XIII"
+              "Mining Level 10",
+              "Mining Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -777,8 +597,8 @@
           },
           {
             "name": [
-              "Mining Level 13",
-              "Mining Level XIII"
+              "Mining Level 10",
+              "Mining Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -797,8 +617,8 @@
           },
           {
             "name": [
-              "Mining Level 13",
-              "Mining Level XIII"
+              "Mining Level 10",
+              "Mining Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Mining Level 14",
-              "Mining Level XIV"
+              "Mining Level 11",
+              "Mining Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,8 +657,8 @@
           },
           {
             "name": [
-              "Mining Level 14",
-              "Mining Level XIV"
+              "Mining Level 11",
+              "Mining Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -857,8 +677,8 @@
           },
           {
             "name": [
-              "Mining Level 14",
-              "Mining Level XIV"
+              "Mining Level 11",
+              "Mining Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -872,16 +692,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mining Level 15",
-              "Mining Level XV"
+              "Mining Level 12",
+              "Mining Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -900,8 +717,8 @@
           },
           {
             "name": [
-              "Mining Level 15",
-              "Mining Level XV"
+              "Mining Level 12",
+              "Mining Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -920,8 +737,8 @@
           },
           {
             "name": [
-              "Mining Level 15",
-              "Mining Level XV"
+              "Mining Level 12",
+              "Mining Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -940,8 +757,8 @@
           },
           {
             "name": [
-              "Mining Level 16",
-              "Mining Level XVI"
+              "Mining Level 13",
+              "Mining Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -960,8 +777,8 @@
           },
           {
             "name": [
-              "Mining Level 16",
-              "Mining Level XVI"
+              "Mining Level 13",
+              "Mining Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -980,8 +797,8 @@
           },
           {
             "name": [
-              "Mining Level 16",
-              "Mining Level XVI"
+              "Mining Level 13",
+              "Mining Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1000,8 +817,8 @@
           },
           {
             "name": [
-              "Mining Level 17",
-              "Mining Level XVII"
+              "Mining Level 14",
+              "Mining Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1020,8 +837,8 @@
           },
           {
             "name": [
-              "Mining Level 17",
-              "Mining Level XVII"
+              "Mining Level 14",
+              "Mining Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1040,8 +857,8 @@
           },
           {
             "name": [
-              "Mining Level 17",
-              "Mining Level XVII"
+              "Mining Level 14",
+              "Mining Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1055,13 +872,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Mining Level 18",
-              "Mining Level XVIII"
+              "Mining Level 15",
+              "Mining Level XV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1080,6 +900,166 @@
           },
           {
             "name": [
+              "Mining Level 15",
+              "Mining Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 15",
+              "Mining Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 16",
+              "Mining Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 16",
+              "Mining Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 16",
+              "Mining Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 17",
+              "Mining Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 17",
+              "Mining Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 17",
+              "Mining Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Mining Level 18",
               "Mining Level XVIII"
             ],
@@ -1091,7 +1071,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/locked/down_right",
+      "id": "skyblock_gui:skills/mining/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 18",
+              "Mining Level XVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1111,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "id": "skyblock_gui:skills/mining/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1131,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "id": "skyblock_gui:skills/mining/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "id": "skyblock_gui:skills/mining/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/unlocked/left_down",
+      "id": "skyblock_gui:skills/mining/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -1194,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/unlocking/left_down",
+      "id": "skyblock_gui:skills/mining/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1205,6 +1205,429 @@
             "name": [
               "Mining Level 20",
               "Mining Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 20",
+              "Mining Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 21",
+              "Mining Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 21",
+              "Mining Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 21",
+              "Mining Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 22",
+              "Mining Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 22",
+              "Mining Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 22",
+              "Mining Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 23",
+              "Mining Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 23",
+              "Mining Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 23",
+              "Mining Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 24",
+              "Mining Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 24",
+              "Mining Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 24",
+              "Mining Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 25",
+              "Mining Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 25",
+              "Mining Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 25",
+              "Mining Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 26",
+              "Mining Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 26",
+              "Mining Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 26",
+              "Mining Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 27",
+              "Mining Level XXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 27",
+              "Mining Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1646,8 @@
           },
           {
             "name": [
-              "Mining Level 20",
-              "Mining Level XX"
+              "Mining Level 27",
+              "Mining Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1666,8 @@
           },
           {
             "name": [
-              "Mining Level 21",
-              "Mining Level XXI"
+              "Mining Level 28",
+              "Mining Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1686,8 @@
           },
           {
             "name": [
-              "Mining Level 21",
-              "Mining Level XXI"
+              "Mining Level 28",
+              "Mining Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1706,8 @@
           },
           {
             "name": [
-              "Mining Level 21",
-              "Mining Level XXI"
+              "Mining Level 28",
+              "Mining Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1726,8 @@
           },
           {
             "name": [
-              "Mining Level 22",
-              "Mining Level XXII"
+              "Mining Level 29",
+              "Mining Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1746,8 @@
           },
           {
             "name": [
-              "Mining Level 22",
-              "Mining Level XXII"
+              "Mining Level 29",
+              "Mining Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,8 +1766,494 @@
           },
           {
             "name": [
-              "Mining Level 22",
-              "Mining Level XXII"
+              "Mining Level 29",
+              "Mining Level XXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 30",
+              "Mining Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 30",
+              "Mining Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 30",
+              "Mining Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 31",
+              "Mining Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 31",
+              "Mining Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 31",
+              "Mining Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 32",
+              "Mining Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 32",
+              "Mining Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 32",
+              "Mining Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 33",
+              "Mining Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 33",
+              "Mining Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 33",
+              "Mining Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 34",
+              "Mining Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 34",
+              "Mining Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 34",
+              "Mining Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 35",
+              "Mining Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 35",
+              "Mining Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 35",
+              "Mining Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 36",
+              "Mining Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 36",
+              "Mining Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 36",
+              "Mining Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 37",
+              "Mining Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 37",
+              "Mining Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 37",
+              "Mining Level XXXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1363,8 +2272,8 @@
           },
           {
             "name": [
-              "Mining Level 23",
-              "Mining Level XXIII"
+              "Mining Level 38",
+              "Mining Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1383,8 +2292,8 @@
           },
           {
             "name": [
-              "Mining Level 23",
-              "Mining Level XXIII"
+              "Mining Level 38",
+              "Mining Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1403,8 +2312,8 @@
           },
           {
             "name": [
-              "Mining Level 23",
-              "Mining Level XXIII"
+              "Mining Level 38",
+              "Mining Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1423,8 +2332,8 @@
           },
           {
             "name": [
-              "Mining Level 24",
-              "Mining Level XXIV"
+              "Mining Level 39",
+              "Mining Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1443,8 +2352,8 @@
           },
           {
             "name": [
-              "Mining Level 24",
-              "Mining Level XXIV"
+              "Mining Level 39",
+              "Mining Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1463,8 +2372,1220 @@
           },
           {
             "name": [
-              "Mining Level 24",
-              "Mining Level XXIV"
+              "Mining Level 39",
+              "Mining Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 40",
+              "Mining Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 40",
+              "Mining Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 40",
+              "Mining Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 41",
+              "Mining Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 41",
+              "Mining Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 41",
+              "Mining Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 42",
+              "Mining Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 42",
+              "Mining Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 42",
+              "Mining Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 43",
+              "Mining Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 43",
+              "Mining Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 43",
+              "Mining Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 44",
+              "Mining Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 44",
+              "Mining Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 44",
+              "Mining Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 45",
+              "Mining Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 45",
+              "Mining Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 45",
+              "Mining Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 46",
+              "Mining Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 46",
+              "Mining Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 46",
+              "Mining Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 47",
+              "Mining Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 47",
+              "Mining Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 47",
+              "Mining Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 48",
+              "Mining Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 48",
+              "Mining Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 48",
+              "Mining Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 49",
+              "Mining Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 49",
+              "Mining Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 49",
+              "Mining Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 50",
+              "Mining Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 50",
+              "Mining Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 50",
+              "Mining Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 51",
+              "Mining Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 51",
+              "Mining Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 51",
+              "Mining Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 52",
+              "Mining Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 52",
+              "Mining Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 52",
+              "Mining Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 53",
+              "Mining Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 53",
+              "Mining Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 53",
+              "Mining Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 54",
+              "Mining Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 54",
+              "Mining Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 54",
+              "Mining Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:iron_block"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 55",
+              "Mining Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 55",
+              "Mining Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 55",
+              "Mining Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 56",
+              "Mining Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 56",
+              "Mining Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 56",
+              "Mining Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 57",
+              "Mining Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 57",
+              "Mining Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 57",
+              "Mining Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 58",
+              "Mining Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 58",
+              "Mining Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 58",
+              "Mining Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 59",
+              "Mining Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 59",
+              "Mining Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/mining/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Mining Level 59",
+              "Mining Level LIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1475,2127 +3596,6 @@
     },
     {
       "id": "skyblock_gui:skills/mining/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 25",
-              "Mining Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 25",
-              "Mining Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 25",
-              "Mining Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 26",
-              "Mining Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 26",
-              "Mining Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 26",
-              "Mining Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 27",
-              "Mining Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 27",
-              "Mining Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 27",
-              "Mining Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 28",
-              "Mining Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 28",
-              "Mining Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 28",
-              "Mining Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 29",
-              "Mining Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 29",
-              "Mining Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 29",
-              "Mining Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 30",
-              "Mining Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 30",
-              "Mining Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 30",
-              "Mining Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 31",
-              "Mining Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 31",
-              "Mining Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 31",
-              "Mining Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 32",
-              "Mining Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 32",
-              "Mining Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 32",
-              "Mining Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 33",
-              "Mining Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 33",
-              "Mining Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 33",
-              "Mining Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 34",
-              "Mining Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 34",
-              "Mining Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 34",
-              "Mining Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 35",
-              "Mining Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 35",
-              "Mining Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 35",
-              "Mining Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 36",
-              "Mining Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 36",
-              "Mining Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 36",
-              "Mining Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 37",
-              "Mining Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 37",
-              "Mining Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 37",
-              "Mining Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 38",
-              "Mining Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 38",
-              "Mining Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 38",
-              "Mining Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 39",
-              "Mining Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 39",
-              "Mining Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 39",
-              "Mining Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 40",
-              "Mining Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 40",
-              "Mining Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 40",
-              "Mining Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 41",
-              "Mining Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 41",
-              "Mining Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 41",
-              "Mining Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 42",
-              "Mining Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 42",
-              "Mining Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 42",
-              "Mining Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 43",
-              "Mining Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 43",
-              "Mining Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 43",
-              "Mining Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 44",
-              "Mining Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 44",
-              "Mining Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 44",
-              "Mining Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 45",
-              "Mining Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 45",
-              "Mining Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 45",
-              "Mining Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 46",
-              "Mining Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 46",
-              "Mining Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 46",
-              "Mining Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 47",
-              "Mining Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 47",
-              "Mining Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 47",
-              "Mining Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 48",
-              "Mining Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 48",
-              "Mining Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 48",
-              "Mining Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 49",
-              "Mining Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 49",
-              "Mining Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 49",
-              "Mining Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 50",
-              "Mining Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 50",
-              "Mining Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 50",
-              "Mining Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 51",
-              "Mining Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 51",
-              "Mining Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 51",
-              "Mining Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 52",
-              "Mining Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 52",
-              "Mining Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 52",
-              "Mining Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 53",
-              "Mining Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 53",
-              "Mining Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 53",
-              "Mining Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 54",
-              "Mining Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 54",
-              "Mining Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 54",
-              "Mining Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:iron_block"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 55",
-              "Mining Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 55",
-              "Mining Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 55",
-              "Mining Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 56",
-              "Mining Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 56",
-              "Mining Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 56",
-              "Mining Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 57",
-              "Mining Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 57",
-              "Mining Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 57",
-              "Mining Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 58",
-              "Mining Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 58",
-              "Mining Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 58",
-              "Mining Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 59",
-              "Mining Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 59",
-              "Mining Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Mining Level 59",
-              "Mining Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/mining/unlocked/left_end",
       "target": {
         "conditions": [
           {
@@ -3618,7 +3618,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/unlocking/left_end",
+      "id": "skyblock_gui:skills/mining/unlocking/up_end",
       "target": {
         "conditions": [
           {
@@ -3638,7 +3638,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/mining/locked/left_end",
+      "id": "skyblock_gui:skills/mining/locked/up_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/runecrafting.json
+++ b/repo/guis/skills/runecrafting.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/start_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/start_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/start_down",
+      "id": "skyblock_gui:skills/runecrafting/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Runecrafting Level 1",
               "Runecrafting Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 2",
-              "Runecrafting Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 2",
-              "Runecrafting Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 2",
-              "Runecrafting Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 3",
-              "Runecrafting Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 3",
-              "Runecrafting Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 3",
-              "Runecrafting Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 4",
-              "Runecrafting Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 4",
-              "Runecrafting Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/runecrafting/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Runecrafting Level 4",
-              "Runecrafting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -266,16 +86,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:end_portal_frame"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Runecrafting Level 5",
-              "Runecrafting Level V"
+              "Runecrafting Level 2",
+              "Runecrafting Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -294,8 +111,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 5",
-              "Runecrafting Level V"
+              "Runecrafting Level 2",
+              "Runecrafting Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -314,8 +131,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 5",
-              "Runecrafting Level V"
+              "Runecrafting Level 2",
+              "Runecrafting Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -334,8 +151,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 6",
-              "Runecrafting Level VI"
+              "Runecrafting Level 3",
+              "Runecrafting Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -354,8 +171,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 6",
-              "Runecrafting Level VI"
+              "Runecrafting Level 3",
+              "Runecrafting Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -374,8 +191,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 6",
-              "Runecrafting Level VI"
+              "Runecrafting Level 3",
+              "Runecrafting Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -394,8 +211,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 7",
-              "Runecrafting Level VII"
+              "Runecrafting Level 4",
+              "Runecrafting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -414,8 +231,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 7",
-              "Runecrafting Level VII"
+              "Runecrafting Level 4",
+              "Runecrafting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -434,8 +251,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 7",
-              "Runecrafting Level VII"
+              "Runecrafting Level 4",
+              "Runecrafting Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -449,13 +266,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:end_portal_frame"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Runecrafting Level 8",
-              "Runecrafting Level VIII"
+              "Runecrafting Level 5",
+              "Runecrafting Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -474,8 +294,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 8",
-              "Runecrafting Level VIII"
+              "Runecrafting Level 5",
+              "Runecrafting Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -494,8 +314,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 8",
-              "Runecrafting Level VIII"
+              "Runecrafting Level 5",
+              "Runecrafting Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 9",
-              "Runecrafting Level IX"
+              "Runecrafting Level 6",
+              "Runecrafting Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,8 +354,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 9",
-              "Runecrafting Level IX"
+              "Runecrafting Level 6",
+              "Runecrafting Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -554,8 +374,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 9",
-              "Runecrafting Level IX"
+              "Runecrafting Level 6",
+              "Runecrafting Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -569,16 +389,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:end_portal_frame"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Runecrafting Level 10",
-              "Runecrafting Level X"
+              "Runecrafting Level 7",
+              "Runecrafting Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -597,8 +414,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 10",
-              "Runecrafting Level X"
+              "Runecrafting Level 7",
+              "Runecrafting Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -617,8 +434,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 10",
-              "Runecrafting Level X"
+              "Runecrafting Level 7",
+              "Runecrafting Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -637,8 +454,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 11",
-              "Runecrafting Level XI"
+              "Runecrafting Level 8",
+              "Runecrafting Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -657,8 +474,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 11",
-              "Runecrafting Level XI"
+              "Runecrafting Level 8",
+              "Runecrafting Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -677,8 +494,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 11",
-              "Runecrafting Level XI"
+              "Runecrafting Level 8",
+              "Runecrafting Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -697,8 +514,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 12",
-              "Runecrafting Level XII"
+              "Runecrafting Level 9",
+              "Runecrafting Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -717,8 +534,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 12",
-              "Runecrafting Level XII"
+              "Runecrafting Level 9",
+              "Runecrafting Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -737,8 +554,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 12",
-              "Runecrafting Level XII"
+              "Runecrafting Level 9",
+              "Runecrafting Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -752,13 +569,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:end_portal_frame"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Runecrafting Level 13",
-              "Runecrafting Level XIII"
+              "Runecrafting Level 10",
+              "Runecrafting Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -777,8 +597,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 13",
-              "Runecrafting Level XIII"
+              "Runecrafting Level 10",
+              "Runecrafting Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -797,8 +617,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 13",
-              "Runecrafting Level XIII"
+              "Runecrafting Level 10",
+              "Runecrafting Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 14",
-              "Runecrafting Level XIV"
+              "Runecrafting Level 11",
+              "Runecrafting Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,8 +657,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 14",
-              "Runecrafting Level XIV"
+              "Runecrafting Level 11",
+              "Runecrafting Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -857,8 +677,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 14",
-              "Runecrafting Level XIV"
+              "Runecrafting Level 11",
+              "Runecrafting Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -872,16 +692,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:end_portal_frame"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Runecrafting Level 15",
-              "Runecrafting Level XV"
+              "Runecrafting Level 12",
+              "Runecrafting Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -900,8 +717,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 15",
-              "Runecrafting Level XV"
+              "Runecrafting Level 12",
+              "Runecrafting Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -920,8 +737,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 15",
-              "Runecrafting Level XV"
+              "Runecrafting Level 12",
+              "Runecrafting Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -940,8 +757,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 16",
-              "Runecrafting Level XVI"
+              "Runecrafting Level 13",
+              "Runecrafting Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -960,8 +777,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 16",
-              "Runecrafting Level XVI"
+              "Runecrafting Level 13",
+              "Runecrafting Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -980,8 +797,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 16",
-              "Runecrafting Level XVI"
+              "Runecrafting Level 13",
+              "Runecrafting Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1000,8 +817,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 17",
-              "Runecrafting Level XVII"
+              "Runecrafting Level 14",
+              "Runecrafting Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1020,8 +837,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 17",
-              "Runecrafting Level XVII"
+              "Runecrafting Level 14",
+              "Runecrafting Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1040,8 +857,8 @@
           },
           {
             "name": [
-              "Runecrafting Level 17",
-              "Runecrafting Level XVII"
+              "Runecrafting Level 14",
+              "Runecrafting Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1055,13 +872,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:end_portal_frame"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Runecrafting Level 18",
-              "Runecrafting Level XVIII"
+              "Runecrafting Level 15",
+              "Runecrafting Level XV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1080,6 +900,166 @@
           },
           {
             "name": [
+              "Runecrafting Level 15",
+              "Runecrafting Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 15",
+              "Runecrafting Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 16",
+              "Runecrafting Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 16",
+              "Runecrafting Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 16",
+              "Runecrafting Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 17",
+              "Runecrafting Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 17",
+              "Runecrafting Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 17",
+              "Runecrafting Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Runecrafting Level 18",
               "Runecrafting Level XVIII"
             ],
@@ -1091,7 +1071,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/down_right",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Runecrafting Level 18",
+              "Runecrafting Level XVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/runecrafting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1111,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/left_right",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1131,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/left_right",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/left_right",
+      "id": "skyblock_gui:skills/runecrafting/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/left_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -1194,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/left_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1214,7 +1214,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/left_down",
+      "id": "skyblock_gui:skills/runecrafting/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -1234,7 +1234,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -1254,7 +1254,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -1274,7 +1274,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -1294,7 +1294,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/left_up",
       "target": {
         "conditions": [
           {
@@ -1314,7 +1314,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/left_up",
       "target": {
         "conditions": [
           {
@@ -1334,7 +1334,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/locked/left_up",
       "target": {
         "conditions": [
           {
@@ -1354,7 +1354,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -1374,7 +1374,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -1394,7 +1394,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -1414,7 +1414,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -1434,7 +1434,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/up_down",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -1454,7 +1454,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/up_down",
+      "id": "skyblock_gui:skills/runecrafting/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -1474,7 +1474,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocked/up_end",
+      "id": "skyblock_gui:skills/runecrafting/unlocked/down_end",
       "target": {
         "conditions": [
           {
@@ -1497,7 +1497,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/unlocking/up_end",
+      "id": "skyblock_gui:skills/runecrafting/unlocking/down_end",
       "target": {
         "conditions": [
           {
@@ -1517,7 +1517,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/runecrafting/locked/up_end",
+      "id": "skyblock_gui:skills/runecrafting/locked/down_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/social.json
+++ b/repo/guis/skills/social.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/start_down",
+      "id": "skyblock_gui:skills/social/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/start_down",
+      "id": "skyblock_gui:skills/social/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/start_down",
+      "id": "skyblock_gui:skills/social/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Social Level 1",
               "Social Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 2",
-              "Social Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 2",
-              "Social Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 2",
-              "Social Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 3",
-              "Social Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 3",
-              "Social Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 3",
-              "Social Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 4",
-              "Social Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 4",
-              "Social Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/social/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Social Level 4",
-              "Social Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -266,16 +86,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_powder"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Social Level 5",
-              "Social Level V"
+              "Social Level 2",
+              "Social Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -294,8 +111,8 @@
           },
           {
             "name": [
-              "Social Level 5",
-              "Social Level V"
+              "Social Level 2",
+              "Social Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -314,8 +131,8 @@
           },
           {
             "name": [
-              "Social Level 5",
-              "Social Level V"
+              "Social Level 2",
+              "Social Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -334,8 +151,8 @@
           },
           {
             "name": [
-              "Social Level 6",
-              "Social Level VI"
+              "Social Level 3",
+              "Social Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -354,8 +171,8 @@
           },
           {
             "name": [
-              "Social Level 6",
-              "Social Level VI"
+              "Social Level 3",
+              "Social Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -374,8 +191,8 @@
           },
           {
             "name": [
-              "Social Level 6",
-              "Social Level VI"
+              "Social Level 3",
+              "Social Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -394,8 +211,8 @@
           },
           {
             "name": [
-              "Social Level 7",
-              "Social Level VII"
+              "Social Level 4",
+              "Social Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -414,8 +231,8 @@
           },
           {
             "name": [
-              "Social Level 7",
-              "Social Level VII"
+              "Social Level 4",
+              "Social Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -434,8 +251,8 @@
           },
           {
             "name": [
-              "Social Level 7",
-              "Social Level VII"
+              "Social Level 4",
+              "Social Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -449,13 +266,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_powder"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Social Level 8",
-              "Social Level VIII"
+              "Social Level 5",
+              "Social Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -474,8 +294,8 @@
           },
           {
             "name": [
-              "Social Level 8",
-              "Social Level VIII"
+              "Social Level 5",
+              "Social Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -494,8 +314,8 @@
           },
           {
             "name": [
-              "Social Level 8",
-              "Social Level VIII"
+              "Social Level 5",
+              "Social Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Social Level 9",
-              "Social Level IX"
+              "Social Level 6",
+              "Social Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,8 +354,8 @@
           },
           {
             "name": [
-              "Social Level 9",
-              "Social Level IX"
+              "Social Level 6",
+              "Social Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -554,8 +374,8 @@
           },
           {
             "name": [
-              "Social Level 9",
-              "Social Level IX"
+              "Social Level 6",
+              "Social Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -569,16 +389,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_powder"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Social Level 10",
-              "Social Level X"
+              "Social Level 7",
+              "Social Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -597,8 +414,8 @@
           },
           {
             "name": [
-              "Social Level 10",
-              "Social Level X"
+              "Social Level 7",
+              "Social Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -617,8 +434,8 @@
           },
           {
             "name": [
-              "Social Level 10",
-              "Social Level X"
+              "Social Level 7",
+              "Social Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -637,8 +454,8 @@
           },
           {
             "name": [
-              "Social Level 11",
-              "Social Level XI"
+              "Social Level 8",
+              "Social Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -657,8 +474,8 @@
           },
           {
             "name": [
-              "Social Level 11",
-              "Social Level XI"
+              "Social Level 8",
+              "Social Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -677,8 +494,8 @@
           },
           {
             "name": [
-              "Social Level 11",
-              "Social Level XI"
+              "Social Level 8",
+              "Social Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -697,8 +514,8 @@
           },
           {
             "name": [
-              "Social Level 12",
-              "Social Level XII"
+              "Social Level 9",
+              "Social Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -717,8 +534,8 @@
           },
           {
             "name": [
-              "Social Level 12",
-              "Social Level XII"
+              "Social Level 9",
+              "Social Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -737,8 +554,8 @@
           },
           {
             "name": [
-              "Social Level 12",
-              "Social Level XII"
+              "Social Level 9",
+              "Social Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -752,13 +569,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_powder"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Social Level 13",
-              "Social Level XIII"
+              "Social Level 10",
+              "Social Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -777,8 +597,8 @@
           },
           {
             "name": [
-              "Social Level 13",
-              "Social Level XIII"
+              "Social Level 10",
+              "Social Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -797,8 +617,8 @@
           },
           {
             "name": [
-              "Social Level 13",
-              "Social Level XIII"
+              "Social Level 10",
+              "Social Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Social Level 14",
-              "Social Level XIV"
+              "Social Level 11",
+              "Social Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,8 +657,8 @@
           },
           {
             "name": [
-              "Social Level 14",
-              "Social Level XIV"
+              "Social Level 11",
+              "Social Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -857,8 +677,8 @@
           },
           {
             "name": [
-              "Social Level 14",
-              "Social Level XIV"
+              "Social Level 11",
+              "Social Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -872,16 +692,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:blaze_powder"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Social Level 15",
-              "Social Level XV"
+              "Social Level 12",
+              "Social Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -900,8 +717,8 @@
           },
           {
             "name": [
-              "Social Level 15",
-              "Social Level XV"
+              "Social Level 12",
+              "Social Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -920,8 +737,8 @@
           },
           {
             "name": [
-              "Social Level 15",
-              "Social Level XV"
+              "Social Level 12",
+              "Social Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -940,8 +757,8 @@
           },
           {
             "name": [
-              "Social Level 16",
-              "Social Level XVI"
+              "Social Level 13",
+              "Social Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -960,8 +777,8 @@
           },
           {
             "name": [
-              "Social Level 16",
-              "Social Level XVI"
+              "Social Level 13",
+              "Social Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -980,8 +797,8 @@
           },
           {
             "name": [
-              "Social Level 16",
-              "Social Level XVI"
+              "Social Level 13",
+              "Social Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1000,8 +817,8 @@
           },
           {
             "name": [
-              "Social Level 17",
-              "Social Level XVII"
+              "Social Level 14",
+              "Social Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1020,8 +837,8 @@
           },
           {
             "name": [
-              "Social Level 17",
-              "Social Level XVII"
+              "Social Level 14",
+              "Social Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1040,8 +857,8 @@
           },
           {
             "name": [
-              "Social Level 17",
-              "Social Level XVII"
+              "Social Level 14",
+              "Social Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1055,13 +872,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:blaze_powder"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Social Level 18",
-              "Social Level XVIII"
+              "Social Level 15",
+              "Social Level XV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1080,6 +900,166 @@
           },
           {
             "name": [
+              "Social Level 15",
+              "Social Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 15",
+              "Social Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 16",
+              "Social Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 16",
+              "Social Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 16",
+              "Social Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 17",
+              "Social Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 17",
+              "Social Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 17",
+              "Social Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Social Level 18",
               "Social Level XVIII"
             ],
@@ -1091,7 +1071,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/down_right",
+      "id": "skyblock_gui:skills/social/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Social Level 18",
+              "Social Level XVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/social/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1111,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/left_right",
+      "id": "skyblock_gui:skills/social/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1131,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/left_right",
+      "id": "skyblock_gui:skills/social/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/left_right",
+      "id": "skyblock_gui:skills/social/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/left_down",
+      "id": "skyblock_gui:skills/social/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -1194,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/left_down",
+      "id": "skyblock_gui:skills/social/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1214,7 +1214,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/left_down",
+      "id": "skyblock_gui:skills/social/locked/up_right",
       "target": {
         "conditions": [
           {
@@ -1234,7 +1234,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/up_down",
+      "id": "skyblock_gui:skills/social/unlocked/left_right",
       "target": {
         "conditions": [
           {
@@ -1254,7 +1254,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/up_down",
+      "id": "skyblock_gui:skills/social/unlocking/left_right",
       "target": {
         "conditions": [
           {
@@ -1274,7 +1274,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/up_down",
+      "id": "skyblock_gui:skills/social/locked/left_right",
       "target": {
         "conditions": [
           {
@@ -1294,7 +1294,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/up_down",
+      "id": "skyblock_gui:skills/social/unlocked/left_up",
       "target": {
         "conditions": [
           {
@@ -1314,7 +1314,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/up_down",
+      "id": "skyblock_gui:skills/social/unlocking/left_up",
       "target": {
         "conditions": [
           {
@@ -1334,7 +1334,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/up_down",
+      "id": "skyblock_gui:skills/social/locked/left_up",
       "target": {
         "conditions": [
           {
@@ -1354,7 +1354,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/up_down",
+      "id": "skyblock_gui:skills/social/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -1374,7 +1374,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/up_down",
+      "id": "skyblock_gui:skills/social/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -1394,7 +1394,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/up_down",
+      "id": "skyblock_gui:skills/social/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -1414,7 +1414,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/up_down",
+      "id": "skyblock_gui:skills/social/unlocked/down_up",
       "target": {
         "conditions": [
           {
@@ -1434,7 +1434,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/up_down",
+      "id": "skyblock_gui:skills/social/unlocking/down_up",
       "target": {
         "conditions": [
           {
@@ -1454,7 +1454,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/up_down",
+      "id": "skyblock_gui:skills/social/locked/down_up",
       "target": {
         "conditions": [
           {
@@ -1474,7 +1474,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocked/up_end",
+      "id": "skyblock_gui:skills/social/unlocked/down_end",
       "target": {
         "conditions": [
           {
@@ -1497,7 +1497,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/unlocking/up_end",
+      "id": "skyblock_gui:skills/social/unlocking/down_end",
       "target": {
         "conditions": [
           {
@@ -1517,7 +1517,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/social/locked/up_end",
+      "id": "skyblock_gui:skills/social/locked/down_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/taming.json
+++ b/repo/guis/skills/taming.json
@@ -14,7 +14,7 @@
             "type": "catharsis:name"
           },
           {
-            "slot": 0,
+            "slot": 27,
             "type": "catharsis:slot"
           }
         ],
@@ -22,7 +22,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/unlocked/start_down",
+      "id": "skyblock_gui:skills/taming/unlocked/start_right",
       "target": {
         "conditions": [
           {
@@ -42,7 +42,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/unlocking/start_down",
+      "id": "skyblock_gui:skills/taming/unlocking/start_right",
       "target": {
         "conditions": [
           {
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/locked/start_down",
+      "id": "skyblock_gui:skills/taming/locked/start_right",
       "target": {
         "conditions": [
           {
@@ -73,186 +73,6 @@
             "name": [
               "Taming Level 1",
               "Taming Level I"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 2",
-              "Taming Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 2",
-              "Taming Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 2",
-              "Taming Level II"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 3",
-              "Taming Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 3",
-              "Taming Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 3",
-              "Taming Level III"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 4",
-              "Taming Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 4",
-              "Taming Level IV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 4",
-              "Taming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -266,16 +86,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Taming Level 5",
-              "Taming Level V"
+              "Taming Level 2",
+              "Taming Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -294,8 +111,8 @@
           },
           {
             "name": [
-              "Taming Level 5",
-              "Taming Level V"
+              "Taming Level 2",
+              "Taming Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -314,8 +131,8 @@
           },
           {
             "name": [
-              "Taming Level 5",
-              "Taming Level V"
+              "Taming Level 2",
+              "Taming Level II"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -334,8 +151,8 @@
           },
           {
             "name": [
-              "Taming Level 6",
-              "Taming Level VI"
+              "Taming Level 3",
+              "Taming Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -354,8 +171,8 @@
           },
           {
             "name": [
-              "Taming Level 6",
-              "Taming Level VI"
+              "Taming Level 3",
+              "Taming Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -374,8 +191,8 @@
           },
           {
             "name": [
-              "Taming Level 6",
-              "Taming Level VI"
+              "Taming Level 3",
+              "Taming Level III"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -394,8 +211,8 @@
           },
           {
             "name": [
-              "Taming Level 7",
-              "Taming Level VII"
+              "Taming Level 4",
+              "Taming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -414,8 +231,8 @@
           },
           {
             "name": [
-              "Taming Level 7",
-              "Taming Level VII"
+              "Taming Level 4",
+              "Taming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -434,8 +251,8 @@
           },
           {
             "name": [
-              "Taming Level 7",
-              "Taming Level VII"
+              "Taming Level 4",
+              "Taming Level IV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -449,13 +266,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Taming Level 8",
-              "Taming Level VIII"
+              "Taming Level 5",
+              "Taming Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -474,8 +294,8 @@
           },
           {
             "name": [
-              "Taming Level 8",
-              "Taming Level VIII"
+              "Taming Level 5",
+              "Taming Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -494,8 +314,8 @@
           },
           {
             "name": [
-              "Taming Level 8",
-              "Taming Level VIII"
+              "Taming Level 5",
+              "Taming Level V"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -514,8 +334,8 @@
           },
           {
             "name": [
-              "Taming Level 9",
-              "Taming Level IX"
+              "Taming Level 6",
+              "Taming Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -534,8 +354,8 @@
           },
           {
             "name": [
-              "Taming Level 9",
-              "Taming Level IX"
+              "Taming Level 6",
+              "Taming Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -554,8 +374,8 @@
           },
           {
             "name": [
-              "Taming Level 9",
-              "Taming Level IX"
+              "Taming Level 6",
+              "Taming Level VI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -569,16 +389,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Taming Level 10",
-              "Taming Level X"
+              "Taming Level 7",
+              "Taming Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -597,8 +414,8 @@
           },
           {
             "name": [
-              "Taming Level 10",
-              "Taming Level X"
+              "Taming Level 7",
+              "Taming Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -617,8 +434,8 @@
           },
           {
             "name": [
-              "Taming Level 10",
-              "Taming Level X"
+              "Taming Level 7",
+              "Taming Level VII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -637,8 +454,8 @@
           },
           {
             "name": [
-              "Taming Level 11",
-              "Taming Level XI"
+              "Taming Level 8",
+              "Taming Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -657,8 +474,8 @@
           },
           {
             "name": [
-              "Taming Level 11",
-              "Taming Level XI"
+              "Taming Level 8",
+              "Taming Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -677,8 +494,8 @@
           },
           {
             "name": [
-              "Taming Level 11",
-              "Taming Level XI"
+              "Taming Level 8",
+              "Taming Level VIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -697,8 +514,8 @@
           },
           {
             "name": [
-              "Taming Level 12",
-              "Taming Level XII"
+              "Taming Level 9",
+              "Taming Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -717,8 +534,8 @@
           },
           {
             "name": [
-              "Taming Level 12",
-              "Taming Level XII"
+              "Taming Level 9",
+              "Taming Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -737,8 +554,8 @@
           },
           {
             "name": [
-              "Taming Level 12",
-              "Taming Level XII"
+              "Taming Level 9",
+              "Taming Level IX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -752,13 +569,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Taming Level 13",
-              "Taming Level XIII"
+              "Taming Level 10",
+              "Taming Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -777,8 +597,8 @@
           },
           {
             "name": [
-              "Taming Level 13",
-              "Taming Level XIII"
+              "Taming Level 10",
+              "Taming Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -797,8 +617,8 @@
           },
           {
             "name": [
-              "Taming Level 13",
-              "Taming Level XIII"
+              "Taming Level 10",
+              "Taming Level X"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -817,8 +637,8 @@
           },
           {
             "name": [
-              "Taming Level 14",
-              "Taming Level XIV"
+              "Taming Level 11",
+              "Taming Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -837,8 +657,8 @@
           },
           {
             "name": [
-              "Taming Level 14",
-              "Taming Level XIV"
+              "Taming Level 11",
+              "Taming Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -857,8 +677,8 @@
           },
           {
             "name": [
-              "Taming Level 14",
-              "Taming Level XIV"
+              "Taming Level 11",
+              "Taming Level XI"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -872,16 +692,13 @@
       "target": {
         "conditions": [
           {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
+            "items": "minecraft:lime_stained_glass_pane",
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Taming Level 15",
-              "Taming Level XV"
+              "Taming Level 12",
+              "Taming Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -900,8 +717,8 @@
           },
           {
             "name": [
-              "Taming Level 15",
-              "Taming Level XV"
+              "Taming Level 12",
+              "Taming Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -920,8 +737,8 @@
           },
           {
             "name": [
-              "Taming Level 15",
-              "Taming Level XV"
+              "Taming Level 12",
+              "Taming Level XII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -940,8 +757,8 @@
           },
           {
             "name": [
-              "Taming Level 16",
-              "Taming Level XVI"
+              "Taming Level 13",
+              "Taming Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -960,8 +777,8 @@
           },
           {
             "name": [
-              "Taming Level 16",
-              "Taming Level XVI"
+              "Taming Level 13",
+              "Taming Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -980,8 +797,8 @@
           },
           {
             "name": [
-              "Taming Level 16",
-              "Taming Level XVI"
+              "Taming Level 13",
+              "Taming Level XIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1000,8 +817,8 @@
           },
           {
             "name": [
-              "Taming Level 17",
-              "Taming Level XVII"
+              "Taming Level 14",
+              "Taming Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1020,8 +837,8 @@
           },
           {
             "name": [
-              "Taming Level 17",
-              "Taming Level XVII"
+              "Taming Level 14",
+              "Taming Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1040,8 +857,8 @@
           },
           {
             "name": [
-              "Taming Level 17",
-              "Taming Level XVII"
+              "Taming Level 14",
+              "Taming Level XIV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1055,13 +872,16 @@
       "target": {
         "conditions": [
           {
-            "items": "minecraft:lime_stained_glass_pane",
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
             "type": "catharsis:item"
           },
           {
             "name": [
-              "Taming Level 18",
-              "Taming Level XVIII"
+              "Taming Level 15",
+              "Taming Level XV"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1080,6 +900,166 @@
           },
           {
             "name": [
+              "Taming Level 15",
+              "Taming Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 15",
+              "Taming Level XV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 16",
+              "Taming Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 16",
+              "Taming Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 16",
+              "Taming Level XVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 17",
+              "Taming Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 17",
+              "Taming Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 17",
+              "Taming Level XVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
               "Taming Level 18",
               "Taming Level XVIII"
             ],
@@ -1091,7 +1071,27 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/locked/down_right",
+      "id": "skyblock_gui:skills/taming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 18",
+              "Taming Level XVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1111,7 +1111,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "id": "skyblock_gui:skills/taming/unlocked/up_down",
       "target": {
         "conditions": [
           {
@@ -1131,7 +1131,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "id": "skyblock_gui:skills/taming/unlocking/up_down",
       "target": {
         "conditions": [
           {
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "id": "skyblock_gui:skills/taming/locked/up_down",
       "target": {
         "conditions": [
           {
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/unlocked/left_down",
+      "id": "skyblock_gui:skills/taming/unlocked/up_right",
       "target": {
         "conditions": [
           {
@@ -1194,7 +1194,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/unlocking/left_down",
+      "id": "skyblock_gui:skills/taming/unlocking/up_right",
       "target": {
         "conditions": [
           {
@@ -1205,6 +1205,429 @@
             "name": [
               "Taming Level 20",
               "Taming Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 20",
+              "Taming Level XX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 21",
+              "Taming Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 21",
+              "Taming Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 21",
+              "Taming Level XXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 22",
+              "Taming Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 22",
+              "Taming Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 22",
+              "Taming Level XXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 23",
+              "Taming Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 23",
+              "Taming Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 23",
+              "Taming Level XXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 24",
+              "Taming Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 24",
+              "Taming Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 24",
+              "Taming Level XXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 25",
+              "Taming Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 25",
+              "Taming Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 25",
+              "Taming Level XXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 26",
+              "Taming Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 26",
+              "Taming Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 26",
+              "Taming Level XXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 27",
+              "Taming Level XXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 27",
+              "Taming Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1223,8 +1646,8 @@
           },
           {
             "name": [
-              "Taming Level 20",
-              "Taming Level XX"
+              "Taming Level 27",
+              "Taming Level XXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1243,8 +1666,8 @@
           },
           {
             "name": [
-              "Taming Level 21",
-              "Taming Level XXI"
+              "Taming Level 28",
+              "Taming Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1263,8 +1686,8 @@
           },
           {
             "name": [
-              "Taming Level 21",
-              "Taming Level XXI"
+              "Taming Level 28",
+              "Taming Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1283,8 +1706,8 @@
           },
           {
             "name": [
-              "Taming Level 21",
-              "Taming Level XXI"
+              "Taming Level 28",
+              "Taming Level XXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1303,8 +1726,8 @@
           },
           {
             "name": [
-              "Taming Level 22",
-              "Taming Level XXII"
+              "Taming Level 29",
+              "Taming Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1323,8 +1746,8 @@
           },
           {
             "name": [
-              "Taming Level 22",
-              "Taming Level XXII"
+              "Taming Level 29",
+              "Taming Level XXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1343,8 +1766,494 @@
           },
           {
             "name": [
-              "Taming Level 22",
-              "Taming Level XXII"
+              "Taming Level 29",
+              "Taming Level XXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 30",
+              "Taming Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 30",
+              "Taming Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 30",
+              "Taming Level XXX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 31",
+              "Taming Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 31",
+              "Taming Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 31",
+              "Taming Level XXXI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 32",
+              "Taming Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 32",
+              "Taming Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 32",
+              "Taming Level XXXII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 33",
+              "Taming Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 33",
+              "Taming Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 33",
+              "Taming Level XXXIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 34",
+              "Taming Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 34",
+              "Taming Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 34",
+              "Taming Level XXXIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 35",
+              "Taming Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 35",
+              "Taming Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 35",
+              "Taming Level XXXV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 36",
+              "Taming Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 36",
+              "Taming Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 36",
+              "Taming Level XXXVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 37",
+              "Taming Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 37",
+              "Taming Level XXXVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 37",
+              "Taming Level XXXVII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1363,8 +2272,8 @@
           },
           {
             "name": [
-              "Taming Level 23",
-              "Taming Level XXIII"
+              "Taming Level 38",
+              "Taming Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1383,8 +2292,8 @@
           },
           {
             "name": [
-              "Taming Level 23",
-              "Taming Level XXIII"
+              "Taming Level 38",
+              "Taming Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1403,8 +2312,8 @@
           },
           {
             "name": [
-              "Taming Level 23",
-              "Taming Level XXIII"
+              "Taming Level 38",
+              "Taming Level XXXVIII"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1423,8 +2332,8 @@
           },
           {
             "name": [
-              "Taming Level 24",
-              "Taming Level XXIV"
+              "Taming Level 39",
+              "Taming Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1443,8 +2352,8 @@
           },
           {
             "name": [
-              "Taming Level 24",
-              "Taming Level XXIV"
+              "Taming Level 39",
+              "Taming Level XXXIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1463,8 +2372,1220 @@
           },
           {
             "name": [
-              "Taming Level 24",
-              "Taming Level XXIV"
+              "Taming Level 39",
+              "Taming Level XXXIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 40",
+              "Taming Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 40",
+              "Taming Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 40",
+              "Taming Level XL"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 41",
+              "Taming Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 41",
+              "Taming Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 41",
+              "Taming Level XLI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 42",
+              "Taming Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 42",
+              "Taming Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 42",
+              "Taming Level XLII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 43",
+              "Taming Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 43",
+              "Taming Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 43",
+              "Taming Level XLIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 44",
+              "Taming Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 44",
+              "Taming Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 44",
+              "Taming Level XLIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 45",
+              "Taming Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 45",
+              "Taming Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 45",
+              "Taming Level XLV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 46",
+              "Taming Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 46",
+              "Taming Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 46",
+              "Taming Level XLVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 47",
+              "Taming Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 47",
+              "Taming Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 47",
+              "Taming Level XLVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 48",
+              "Taming Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 48",
+              "Taming Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 48",
+              "Taming Level XLVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 49",
+              "Taming Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 49",
+              "Taming Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 49",
+              "Taming Level XLIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 50",
+              "Taming Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 50",
+              "Taming Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 50",
+              "Taming Level L"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 51",
+              "Taming Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 51",
+              "Taming Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 51",
+              "Taming Level LI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 52",
+              "Taming Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 52",
+              "Taming Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 52",
+              "Taming Level LII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 53",
+              "Taming Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 53",
+              "Taming Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 53",
+              "Taming Level LIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 54",
+              "Taming Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 54",
+              "Taming Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_up",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 54",
+              "Taming Level LIV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": [
+              "minecraft:lime_stained_glass_pane",
+              "minecraft:golden_carrot"
+            ],
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 55",
+              "Taming Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 55",
+              "Taming Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/down_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 55",
+              "Taming Level LV"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 56",
+              "Taming Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 56",
+              "Taming Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_right",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 56",
+              "Taming Level LVI"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 57",
+              "Taming Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 57",
+              "Taming Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/left_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 57",
+              "Taming Level LVII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 58",
+              "Taming Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 58",
+              "Taming Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 58",
+              "Taming Level LVIII"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:lime_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 59",
+              "Taming Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/unlocking/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:yellow_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 59",
+              "Taming Level LIX"
+            ],
+            "mode": "equals",
+            "type": "catharsis:name"
+          }
+        ],
+        "type": "catharsis:all"
+      }
+    },
+    {
+      "id": "skyblock_gui:skills/taming/locked/up_down",
+      "target": {
+        "conditions": [
+          {
+            "items": "minecraft:red_stained_glass_pane",
+            "type": "catharsis:item"
+          },
+          {
+            "name": [
+              "Taming Level 59",
+              "Taming Level LIX"
             ],
             "mode": "equals",
             "type": "catharsis:name"
@@ -1475,2127 +3596,6 @@
     },
     {
       "id": "skyblock_gui:skills/taming/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 25",
-              "Taming Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 25",
-              "Taming Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 25",
-              "Taming Level XXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 26",
-              "Taming Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 26",
-              "Taming Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 26",
-              "Taming Level XXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 27",
-              "Taming Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 27",
-              "Taming Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 27",
-              "Taming Level XXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 28",
-              "Taming Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 28",
-              "Taming Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 28",
-              "Taming Level XXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 29",
-              "Taming Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 29",
-              "Taming Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 29",
-              "Taming Level XXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 30",
-              "Taming Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 30",
-              "Taming Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 30",
-              "Taming Level XXX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 31",
-              "Taming Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 31",
-              "Taming Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 31",
-              "Taming Level XXXI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 32",
-              "Taming Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 32",
-              "Taming Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 32",
-              "Taming Level XXXII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 33",
-              "Taming Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 33",
-              "Taming Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 33",
-              "Taming Level XXXIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 34",
-              "Taming Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 34",
-              "Taming Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 34",
-              "Taming Level XXXIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 35",
-              "Taming Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 35",
-              "Taming Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 35",
-              "Taming Level XXXV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 36",
-              "Taming Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 36",
-              "Taming Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 36",
-              "Taming Level XXXVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 37",
-              "Taming Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 37",
-              "Taming Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 37",
-              "Taming Level XXXVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 38",
-              "Taming Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 38",
-              "Taming Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 38",
-              "Taming Level XXXVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 39",
-              "Taming Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 39",
-              "Taming Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 39",
-              "Taming Level XXXIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 40",
-              "Taming Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 40",
-              "Taming Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 40",
-              "Taming Level XL"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 41",
-              "Taming Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 41",
-              "Taming Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 41",
-              "Taming Level XLI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 42",
-              "Taming Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 42",
-              "Taming Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 42",
-              "Taming Level XLII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 43",
-              "Taming Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 43",
-              "Taming Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 43",
-              "Taming Level XLIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 44",
-              "Taming Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 44",
-              "Taming Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 44",
-              "Taming Level XLIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 45",
-              "Taming Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 45",
-              "Taming Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 45",
-              "Taming Level XLV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 46",
-              "Taming Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 46",
-              "Taming Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 46",
-              "Taming Level XLVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 47",
-              "Taming Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 47",
-              "Taming Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 47",
-              "Taming Level XLVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 48",
-              "Taming Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 48",
-              "Taming Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 48",
-              "Taming Level XLVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 49",
-              "Taming Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 49",
-              "Taming Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 49",
-              "Taming Level XLIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 50",
-              "Taming Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 50",
-              "Taming Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_end",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 50",
-              "Taming Level L"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 51",
-              "Taming Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 51",
-              "Taming Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/start_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 51",
-              "Taming Level LI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 52",
-              "Taming Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 52",
-              "Taming Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_down",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 52",
-              "Taming Level LII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 53",
-              "Taming Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 53",
-              "Taming Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/up_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 53",
-              "Taming Level LIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 54",
-              "Taming Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 54",
-              "Taming Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 54",
-              "Taming Level LIV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": [
-              "minecraft:lime_stained_glass_pane",
-              "minecraft:golden_carrot"
-            ],
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 55",
-              "Taming Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 55",
-              "Taming Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 55",
-              "Taming Level LV"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 56",
-              "Taming Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 56",
-              "Taming Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 56",
-              "Taming Level LVI"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 57",
-              "Taming Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 57",
-              "Taming Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_up",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 57",
-              "Taming Level LVII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 58",
-              "Taming Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 58",
-              "Taming Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/down_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 58",
-              "Taming Level LVIII"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:lime_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 59",
-              "Taming Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocking/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:yellow_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 59",
-              "Taming Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/locked/left_right",
-      "target": {
-        "conditions": [
-          {
-            "items": "minecraft:red_stained_glass_pane",
-            "type": "catharsis:item"
-          },
-          {
-            "name": [
-              "Taming Level 59",
-              "Taming Level LIX"
-            ],
-            "mode": "equals",
-            "type": "catharsis:name"
-          }
-        ],
-        "type": "catharsis:all"
-      }
-    },
-    {
-      "id": "skyblock_gui:skills/taming/unlocked/left_end",
       "target": {
         "conditions": [
           {
@@ -3618,7 +3618,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/unlocking/left_end",
+      "id": "skyblock_gui:skills/taming/unlocking/up_end",
       "target": {
         "conditions": [
           {
@@ -3638,7 +3638,7 @@
       }
     },
     {
-      "id": "skyblock_gui:skills/taming/locked/left_end",
+      "id": "skyblock_gui:skills/taming/locked/up_end",
       "target": {
         "conditions": [
           {

--- a/repo/guis/skills/your_skills.json
+++ b/repo/guis/skills/your_skills.json
@@ -101,6 +101,13 @@
         "type": "catharsis:slot",
         "slot": 34
       }
+    },
+    {
+      "id": "skyblock_gui:skills/show_skill_rankings/icon",
+      "target": {
+        "type": "catharsis:slot",
+        "slot": 53
+      }
     }
   ]
 }

--- a/scripts/skill_generator.kt
+++ b/scripts/skill_generator.kt
@@ -1,11 +1,6 @@
 import me.owdding.catharsis.features.gui.definitions.GuiDefinition
 import me.owdding.catharsis.features.gui.definitions.conditions.GuiDefinitionTitleCondition
-import me.owdding.catharsis.features.gui.definitions.slots.GuiSlotDefinition
-import me.owdding.catharsis.features.gui.definitions.slots.SlotAllCondition
-import me.owdding.catharsis.features.gui.definitions.slots.SlotAnyCondition
-import me.owdding.catharsis.features.gui.definitions.slots.SlotIndexCondition
-import me.owdding.catharsis.features.gui.definitions.slots.SlotItemCondition
-import me.owdding.catharsis.features.gui.definitions.slots.SlotNameCondition
+import me.owdding.catharsis.features.gui.definitions.slots.*
 import me.owdding.catharsis.features.gui.matchers.EqualsTextMatcher
 import me.owdding.catharsis.features.gui.matchers.RegexTextMatcher
 import net.minecraft.world.item.Item
@@ -30,20 +25,16 @@ fun createSkill(
     extraSlots: () -> List<GuiSlotDefinition> = ::emptyList,
 ) {
     val nodes = (1..maxLevel).flatMap { level ->
-        val evalLevel = level % 25
 
-        var direction = when {
-            level % 25 >= 23 -> "up_down"
-            level % 25 == 0 -> "up_end"
-            level % 25 == 1 -> "start_down"
-
-            evalLevel % 10 == 0 -> "left_down"
-            evalLevel % 10 <= 2 -> "up_down"
-            evalLevel % 10 == 3 -> "up_right"
-            evalLevel % 10 == 4 || evalLevel % 10 == 9 -> "left_right"
-            evalLevel % 10 == 5 -> "left_up"
-            evalLevel % 10 <= 7 -> "down_up"
-            else -> "down_right"
+        var direction = if (level == 1) "start_right" else when ((level - 2) % 10) {
+            0 -> "left_up"
+            1, 2 -> "down_up"
+            3 -> "down_right"
+            4 -> "left_right"
+            5 -> "left_down"
+            6, 7 -> "up_down"
+            8 -> "up_right"
+            else -> "left_right" // 9
         }
 
         if (maxLevel == level) {
@@ -87,7 +78,7 @@ fun createSkill(
                     id = Identifiers.of("skyblock_gui", "${pluralDataType}/${extra}${skillName.lowercase()}/icon"),
                     target = SlotAllCondition(
                         SlotNameCondition(EqualsTextMatcher(setOf(icon))),
-                        SlotIndexCondition(0),
+                        SlotIndexCondition(27),
                     ),
                 ),
             )
@@ -126,7 +117,7 @@ fun farming(): List<GuiSlotDefinition> = listOf(
             SlotItemCondition(setOf(Items.SUNFLOWER)),
             SlotAnyCondition(
                 SlotNameCondition(RegexTextMatcher("Garden Level \\d+")),
-                SlotNameCondition(RegexTextMatcher("Garden Level [XIV]+"))
+                SlotNameCondition(RegexTextMatcher("Garden Level [XIV]+")),
             ),
         ),
     ),
@@ -257,7 +248,7 @@ fun catacombs(): List<GuiSlotDefinition> = listOf(
     GuiSlotDefinition(
         id = Identifiers.of("skyblock_gui", "skills/dungeoneering/catacombs/catacombs_profile"),
         target = SlotAllCondition(
-            SlotIndexCondition(45),
+            SlotIndexCondition(41),
             SlotItemCondition(setOf(Items.OAK_SIGN)),
             SlotNameCondition(EqualsTextMatcher("Catacombs Profile")),
         ),
@@ -265,9 +256,37 @@ fun catacombs(): List<GuiSlotDefinition> = listOf(
     GuiSlotDefinition(
         id = Identifiers.of("skyblock_gui", "skills/dungeoneering/catacombs/catacombs_rng_meter"),
         target = SlotAllCondition(
-            SlotIndexCondition(40),
+            SlotIndexCondition(39),
             SlotItemCondition(setOf(Items.PLAYER_HEAD)),
             SlotNameCondition(EqualsTextMatcher("Catacombs RNG Meters")),
+        ),
+    ),
+)
+
+fun catacombsClasses(classType: String): List<GuiSlotDefinition> = listOf(
+    GuiSlotDefinition(
+        id = Identifiers.of("skyblock_gui", "classes/${classType}/class_pasives"),
+        target = SlotAllCondition(
+            SlotIndexCondition(39),
+            SlotItemCondition(setOf(Items.SPLASH_POTION, Items.BLAZE_ROD, Items.IRON_SWORD, Items.BOW, Items.LEATHER_CHESTPLATE)),
+            SlotNameCondition(EqualsTextMatcher("Class Passives")),
+        ),
+    ),
+    GuiSlotDefinition(
+        id = Identifiers.of("skyblock_gui", "classes/${classType}/dungeon_orb_abilities"),
+        target = SlotAllCondition(
+            SlotIndexCondition(40),
+            SlotItemCondition(setOf(Items.PLAYER_HEAD)),
+            SlotNameCondition(EqualsTextMatcher("Dungeon Orb Abilities")),
+        ),
+    ),
+
+    GuiSlotDefinition(
+        id = Identifiers.of("skyblock_gui", "classes/${classType}/ghost_abilities"),
+        target = SlotAllCondition(
+            SlotIndexCondition(41),
+            SlotItemCondition(setOf(Items.PLAYER_HEAD)),
+            SlotNameCondition(EqualsTextMatcher("Ghost Abilities")),
         ),
     ),
 )
@@ -282,7 +301,7 @@ fun skills() {
     createSkill("Alchemy", 50, Items.BLAZE_ROD)
     createSkill("Carpentry", 50, Items.ARMOR_STAND)
     createSkill("Taming", 60, Items.GOLDEN_CARROT)
-    createSkill("Hunting", 60, null, extraSlots = ::hunting)
+    createSkill("Hunting", 25, Items.PRISMARINE_SHARD, extraSlots = ::hunting)
     createSkill(
         "Catacombs",
         50,
@@ -298,9 +317,54 @@ fun skills() {
     createSkill("Runecrafting", 25, Items.END_PORTAL_FRAME, extraSlots = ::runecrafting)
     createSkill("Social", 25, Items.BLAZE_POWDER)
 
-    createSkill("Healer", 50, Items.SPLASH_POTION, title = "Healer Class Perks", icon = "Healer Class", dataType = "class", pluralDataType = "classes")
-    createSkill("Mage", 50, Items.BLAZE_ROD, title = "Mage Class Perks", icon = "Mage Class", dataType = "class", pluralDataType = "classes")
-    createSkill("Berserk", 50, Items.IRON_SWORD, title = "Berserk Class Perks", icon = "Berserk Class", dataType = "class", pluralDataType = "classes")
-    createSkill("Archer", 50, Items.BOW, title = "Archer Class Perks", icon = "Archer Class", dataType = "class", pluralDataType = "classes")
-    createSkill("Tank", 50, Items.LEATHER_CHESTPLATE, title = "Tank Class Perks", icon = "Tank Class", dataType = "class", pluralDataType = "classes")
+    createSkill(
+        "Healer",
+        50,
+        Items.SPLASH_POTION,
+        title = "Healer Class Perks",
+        icon = "Healer Class",
+        dataType = "class",
+        pluralDataType = "classes",
+        extraSlots = { catacombsClasses("healer") },
+    )
+    createSkill(
+        "Mage",
+        50,
+        Items.BLAZE_ROD,
+        title = "Mage Class Perks",
+        icon = "Mage Class",
+        dataType = "class",
+        pluralDataType = "classes",
+        extraSlots = { catacombsClasses("mage") },
+    )
+    createSkill(
+        "Berserk",
+        50,
+        Items.IRON_SWORD,
+        title = "Berserk Class Perks",
+        icon = "Berserk Class",
+        dataType = "class",
+        pluralDataType = "classes",
+        extraSlots = { catacombsClasses("berserk") },
+    )
+    createSkill(
+        "Archer",
+        50,
+        Items.BOW,
+        title = "Archer Class Perks",
+        icon = "Archer Class",
+        dataType = "class",
+        pluralDataType = "classes",
+        extraSlots = { catacombsClasses("archer") },
+    )
+    createSkill(
+        "Tank",
+        50,
+        Items.LEATHER_CHESTPLATE,
+        title = "Tank Class Perks",
+        icon = "Tank Class",
+        dataType = "class",
+        pluralDataType = "classes",
+        extraSlots = { catacombsClasses("tank") },
+    )
 }


### PR DESCRIPTION
also added a few slot definitions that weren't there before (navigation ones for skills, might exist somewhere else and only use slot index instead of title(?))

the new icons in classes might be in the wrong place? idk, if so pls let me know (so like the class passive, the ghost abilities and the orb abilities)