### PR TITLE
fix: optional title and description for separator config option

### DIFF
--- a/src/main/kotlin/me/owdding/catharsis/features/pack/config/PackConfigOptions.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/pack/config/PackConfigOptions.kt
@@ -38,7 +38,7 @@ sealed interface PackConfigOption {
     fun description(value: String?): Component
 
     @GenerateCodec
-    data class Separator(val title: Component, val description: Component) : PackConfigOption {
+    data class Separator(val title: Component = Component.empty(), val description: Component = Component.empty()) : PackConfigOption {
         override val type: MapCodec<out PackConfigOption> = CatharsisCodecs.getMapCodec<Separator>()
         override val id: String? = null
         override fun title(value: String?): Component = title


### PR DESCRIPTION
idk why it wasn't like that originally (I didn't actually check the full commit history, maybe at some point it was?)