### PR TITLE
feat: config command search argument

### DIFF
--- a/src/main/kotlin/me/owdding/catharsis/features/pack/config/PackConfigHandler.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/pack/config/PackConfigHandler.kt
@@ -117,15 +117,28 @@ object PackConfigHandler : ResourceManagerReloadListener {
     @Subscription
     fun onCommand(event: RegisterCommandsEvent) {
         event.register("catharsis config") {
-            thenCallback("id", StringArgumentType.string(), IterableSuggestionProvider(catharsisPackOptions.keys)) {
-                val id = argument<String>("id")
-                val options = getConfig(id).options() ?: run {
-                    Text.of("No config found for $id").sendWithPrefix()
-                    return@thenCallback
+            then("id", StringArgumentType.string(), IterableSuggestionProvider(catharsisPackOptions.keys)) {
+                callback {
+                    val id = argument<String>("id")
+                    openPackConfigScreen(id)
                 }
-                McClient.setScreenAsync { PackConfigScreen(McScreen.self, id, options) }
+                then("search", StringArgumentType.string()) {
+                    callback {
+                        val id = argument<String>("id")
+                        val search = argument<String>("search")
+                        openPackConfigScreen(id, search)
+                    }
+                }
             }
         }
+    }
+
+    fun openPackConfigScreen(id: String, search: String = "") {
+        val options = getConfig(id).options() ?: run {
+            Text.of("No config found for $id").sendWithPrefix()
+            return
+        }
+        McClient.setScreenAsync { PackConfigScreen(McScreen.self, id, options, search) }
     }
 
     override fun onResourceManagerReload(resourceManager: ResourceManager) {

--- a/src/main/kotlin/me/owdding/catharsis/features/pack/config/PackConfigScreen.kt
+++ b/src/main/kotlin/me/owdding/catharsis/features/pack/config/PackConfigScreen.kt
@@ -29,8 +29,8 @@ import java.util.function.Consumer
 import kotlin.math.max
 
 
-class PackConfigScreen(private val parent: Screen?, pack: String, private val options: List<PackConfigOption>) : Screen(Component.empty()) {
-
+class PackConfigScreen @JvmOverloads constructor(private val parent: Screen?, pack: String, private val options: List<PackConfigOption>, commandSearchQuery: String = "") :
+    Screen(Component.empty()) {
     private val config = PackConfigHandler.getConfig(pack)
     private val originalConfigData = config.current.deepCopy()
 
@@ -38,7 +38,7 @@ class PackConfigScreen(private val parent: Screen?, pack: String, private val op
     private val tabs: TabManager = TabManager({ widget -> this.addRenderableWidget(widget) }, { widget -> this.removeWidget(widget) })
     private var navigation: TabNavigationBar? = null
 
-    private var searchQuery: String = ""
+    private var searchQuery: String = commandSearchQuery
     private var searchBox: EditBox? = null
     private var currentTabTitle: Component? = null
 
@@ -54,6 +54,7 @@ class PackConfigScreen(private val parent: Screen?, pack: String, private val op
                         matchingOptions.map(this::getOptionElement).forEach(layout::addChild)
                     }
                 }
+
                 else -> {
                     if (option.matches(searchQuery)) {
                         val layout = contents.getOrPut(GENERAL_TAB) { LinearLayout.vertical().spacing(8) }


### PR DESCRIPTION
`/catharsis config <id> [<search>]` (the brackets mean that it's optional btw, I did not know that)

this might conflict with the feature for changing pack options through commands, but idk surely a better solution can be thought of if that ever gets added :3 (maybe `configsearch` and `configmodify`? idk)