### PR TITLE
fix: bedrock armor not following custom entity animations

### DIFF
--- a/src/main/kotlin/me/owdding/catharsis/utils/geometry/BedrockGeometryRenderer.kt
+++ b/src/main/kotlin/me/owdding/catharsis/utils/geometry/BedrockGeometryRenderer.kt
@@ -48,10 +48,35 @@ private val NEUTRAL_POSES = run {
 
 private fun MeshDefinition.bakeRoot() = LayerDefinition.create(this, HUMANOID_TEXTURE_WIDTH, HUMANOID_TEXTURE_HEIGHT).bakeRoot()
 
+class HumanoidPose(
+    val root: PartPose,
+    val head: PartPose,
+    val body: PartPose,
+    val rightArm: PartPose,
+    val leftArm: PartPose,
+    val rightLeg: PartPose,
+    val leftLeg: PartPose,
+) {
+    companion object {
+        @JvmStatic
+        fun of(model: HumanoidModel<*>) = HumanoidPose(
+            model.root().storePose(),
+            model.head.storePose(),
+            model.body.storePose(),
+            model.rightArm.storePose(),
+            model.leftArm.storePose(),
+            model.rightLeg.storePose(),
+            model.leftLeg.storePose(),
+        )
+    }
+}
+
 object BedrockGeometryRenderer {
 
     @JvmStatic
-    fun render(geometry: BakedBedrockGeometry, slot: EquipmentSlot, model: HumanoidModel<*>, pose: PoseStack.Pose, consumer: VertexConsumer, color: Int, light: Int, overlay: Int) {
+    fun render(geometry: BakedBedrockGeometry, slot: EquipmentSlot, model: HumanoidPose, pose: PoseStack.Pose, consumer: VertexConsumer, color: Int, light: Int, overlay: Int) {
+        applyRoot(model.root, pose)
+
         pose.scale(1f, -1f, 1f)
         pose.translate(0f, -24f / 16f, 0f)
 
@@ -86,6 +111,18 @@ object BedrockGeometryRenderer {
             bone.scale.z = playerBone.zScale
 
             renderBone(bone, pose, consumer, color, light, overlay)
+        }
+    }
+
+    // submitModel does the root for you, submitCustomGeometry doesn't
+    private fun applyRoot(root: PartPose, pose: PoseStack.Pose) {
+        pose.translate(root.x / 16f, root.y / 16f, root.z / 16f)
+
+        if (root.xRot != 0f || root.yRot != 0f || root.zRot != 0f) {
+            pose.rotate(Quaternionf().rotationZYX(root.zRot, root.yRot, root.xRot))
+        }
+        if (root.xScale != 1f || root.yScale != 1f || root.zScale != 1f) {
+            pose.scale(root.xScale, root.yScale, root.zScale)
         }
     }
 

--- a/versions/26.1/src/main/java/me/owdding/catharsis/mixins/armor/HumanoidArmorModelMixin.java
+++ b/versions/26.1/src/main/java/me/owdding/catharsis/mixins/armor/HumanoidArmorModelMixin.java
@@ -5,24 +5,22 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import me.owdding.catharsis.features.armor.models.ArmorModelState;
 import me.owdding.catharsis.hooks.armor.LivingEntityRenderStateHook;
 import me.owdding.catharsis.utils.geometry.BedrockGeometryRenderer;
+import me.owdding.catharsis.utils.geometry.HumanoidPose;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = HumanoidArmorLayer.class, priority = 2000)
-public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState, A extends HumanoidModel<S>> {
-
-    @Shadow
-    protected abstract A getArmorModel(S renderState, EquipmentSlot slot);
+public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState> {
 
     @Inject(method = "renderArmorPiece", at = @At("HEAD"), cancellable = true)
     private void catharsis$onBake(
@@ -36,7 +34,7 @@ public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState, A e
         if (!(state instanceof LivingEntityRenderStateHook hook)) return;
         if (!(hook.catharsis$getArmorDefinitionRenderState().fromSlot(slot) instanceof ArmorModelState.Bedrock renderer)) return;
 
-        A model = this.getArmorModel(state, slot);
+        var pose = HumanoidPose.of((HumanoidModel<?>) ((RenderLayer<?, ?>) (Object) this).getParentModel());
 
         var textures = renderer.getTextures();
         var colors = renderer.getColors();
@@ -48,9 +46,8 @@ public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState, A e
 
             var renderType = isTranslucent ? RenderTypes.entityTranslucent(texture) : RenderTypes.entityCutout(texture);
 
-            nodes.order(i + 1).submitCustomGeometry(stack, renderType, (pose, consumer) -> {
-                model.setupAnim(state);
-                BedrockGeometryRenderer.render(renderer.getGeometry(), slot, model, pose, consumer, color, light, OverlayTexture.NO_OVERLAY);
+            nodes.order(i + 1).submitCustomGeometry(stack, renderType, (matrix, consumer) -> {
+                BedrockGeometryRenderer.render(renderer.getGeometry(), slot, pose, matrix, consumer, color, light, OverlayTexture.NO_OVERLAY);
             });
         }
         ci.cancel();

--- a/versions/26.2/src/main/java/me/owdding/catharsis/mixins/armor/HumanoidArmorModelMixin.java
+++ b/versions/26.2/src/main/java/me/owdding/catharsis/mixins/armor/HumanoidArmorModelMixin.java
@@ -5,24 +5,22 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import me.owdding.catharsis.features.armor.models.ArmorModelState;
 import me.owdding.catharsis.hooks.armor.LivingEntityRenderStateHook;
 import me.owdding.catharsis.utils.geometry.BedrockGeometryRenderer;
+import me.owdding.catharsis.utils.geometry.HumanoidPose;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = HumanoidArmorLayer.class, priority = 2000)
-public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState, A extends HumanoidModel<S>> {
-
-    @Shadow
-    protected abstract A getArmorModel(S renderState, EquipmentSlot slot);
+public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState> {
 
     @Inject(method = "renderArmorPiece", at = @At("HEAD"), cancellable = true)
     private void catharsis$onBake(
@@ -36,7 +34,7 @@ public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState, A e
         if (!(state instanceof LivingEntityRenderStateHook hook)) return;
         if (!(hook.catharsis$getArmorDefinitionRenderState().fromSlot(slot) instanceof ArmorModelState.Bedrock renderer)) return;
 
-        A model = this.getArmorModel(state, slot);
+        var pose = HumanoidPose.of((HumanoidModel<?>) ((RenderLayer<?, ?>) (Object) this).getParentModel());
 
         var textures = renderer.getTextures();
         var colors = renderer.getColors();
@@ -48,9 +46,8 @@ public abstract class HumanoidArmorModelMixin<S extends HumanoidRenderState, A e
 
             var renderType = isTranslucent ? RenderTypes.entityTranslucent(texture) : RenderTypes.entityCutout(texture);
 
-            nodes.order(i + 1).submitCustomGeometry(stack, renderType, (pose, consumer) -> {
-                model.setupAnim(state);
-                BedrockGeometryRenderer.render(renderer.getGeometry(), slot, model, pose, consumer, color, light, OverlayTexture.NO_OVERLAY);
+            nodes.order(i + 1).submitCustomGeometry(stack, renderType, (matrix, consumer) -> {
+                BedrockGeometryRenderer.render(renderer.getGeometry(), slot, pose, matrix, consumer, color, light, OverlayTexture.NO_OVERLAY);
             });
         }
         ci.cancel();


### PR DESCRIPTION
3D armor models stay at the rest pose while the entity animates. Most visible on SkyBlock with Fresh Animations, since helmets are player heads with geo models, so the helmet hangs still while the head moves. Texture armor is unaffected because it goes through submitModel.

submitCustomGeometry runs its lambda during the deferred draw pass, so the setupAnim call in there rebuilds vanilla's pose and discards anything an animation pack applied earlier in the frame. Read the pose from the parent model at submit time instead.

The model root was also never applied, which submitModel does for you. Vanilla barely uses it so it went unnoticed, but animation packs lean the body with it and counter-rotate the head, which without it makes the piece tilt the wrong way. It matters for vanilla swimming and sleeping too.

Tested on 26.1. The 26.2 file was identical so I patched both, but I have not built 26.2.