### PR TITLE
fix(dependabot):not-updating-everything

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ registries:
         type: maven-repository
         url: https://repo.hypixel.net/repository/Hypixel
 
-    parchmentmc:
-        type: maven-repository
-        url: https://maven.parchmentmc.org/
-
     modrinth:
         type: maven-repository
         url: https://api.modrinth.com/maven
@@ -21,7 +17,7 @@ registries:
         type: maven-repository
         url: https://maven.teamresourceful.com/repository/maven-public/
 
-    nucleoid: # what is the proper name for this?
+    nucleoid:
         type: maven-repository
         url: https://maven.nucleoid.xyz/
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,48 @@
 version: 2
+registries:
+
+    devauth:
+        type: maven-repository
+        url: https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1
+
+    hypixelapi:
+        type: maven-repository
+        url: https://repo.hypixel.net/repository/Hypixel
+
+    parchmentmc:
+        type: maven-repository
+        url: https://maven.parchmentmc.org/
+
+    modrinth:
+        type: maven-repository
+        url: https://api.modrinth.com/maven
+
+    teamresourceful:
+        type: maven-repository
+        url: https://maven.teamresourceful.com/repository/maven-public/
+
+    nucleoid: # what is the proper name for this?
+        type: maven-repository
+        url: https://maven.nucleoid.xyz/
+
+    fishstiz:
+        type: maven-repository
+        url: https://raw.githubusercontent.com/fishstiz/maven/m2
+
+    operationpotato-snapshots:
+        type: maven-repository
+        url: https://maven.operationpotato.com/snapshots
+
+    operationpotato-releases:
+        type: maven-repository
+        url: https://maven.operationpotato.com/releases
 updates:
-    - package-ecosystem: "gradle"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      groups:
-          gradle-updates:
-              patterns:
-                  - "*"
+    -   package-ecosystem: gradle
+        directory: /
+        registries: "*"
+        schedule:
+            interval: daily
+        groups:
+            gradle-updates:
+                patterns:
+                    - "*"


### PR DESCRIPTION
updates dependabot config so that it can find all dependencies* 

pretty please someone look ever the names of the repos and tell me if they need any modifications.

registries in dependabot docs were really confusing, at first I thought I actually needed to get some sort of auth going for it to work even for public stuff, but apparently thats optional(?), idk, at least it [works](https://github.com/JustAlex7473/catharsis/pull/6)

*idk if it actually updates every single dependency, but it got a bunch of them on my 1 test, so surely that counts for something!!!